### PR TITLE
Fix: error when accessors being called on DataRef

### DIFF
--- a/python/xorbits/pandas/accessors.py
+++ b/python/xorbits/pandas/accessors.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Union
 
 import pandas
 
+from ..core import DataRef
 from ..core.adapter import (
     MarsDatetimeAccessor,
     MarsStringAccessor,
@@ -27,8 +28,13 @@ from .mars_adapters.core import MarsGetAttrProxy, install_members
 
 @register_converter(from_cls_list=[MarsStringAccessor])
 class StringAccessor(MarsGetAttrProxy):
-    def __init__(self, series):
-        super().__init__(MarsStringAccessor(to_mars(series)))
+    def __init__(self, obj: Union[DataRef, MarsStringAccessor]):
+        if isinstance(obj, MarsStringAccessor):
+            # when the owner of the accessor being xorbits.core.data.Data.
+            super().__init__(obj)
+        elif isinstance(obj, DataRef):
+            # when the owner of the accessor being xorbits.pandas.core.Series.
+            super().__init__(MarsStringAccessor(to_mars(obj)))
 
 
 install_members(
@@ -44,8 +50,13 @@ attach_module_callable_docstring(
 
 @register_converter(from_cls_list=[MarsDatetimeAccessor])
 class DatetimeAccessor(MarsGetAttrProxy):
-    def __init__(self, series):
-        super().__init__(MarsDatetimeAccessor(to_mars(series)))
+    def __init__(self, obj: Union[DataRef, MarsDatetimeAccessor]):
+        if isinstance(obj, MarsDatetimeAccessor):
+            # when the owner of the accessor being xorbits.core.data.Data.
+            super().__init__(obj)
+        elif isinstance(obj, DataRef):
+            # when the owner of the accessor being xorbits.pandas.core.Series.
+            super().__init__(MarsDatetimeAccessor(to_mars(obj)))
 
 
 install_members(

--- a/python/xorbits/pandas/tests/test_accessors.py
+++ b/python/xorbits/pandas/tests/test_accessors.py
@@ -16,13 +16,43 @@
 import pandas as pd
 
 from ... import pandas as xpd
+from ...core import DataRef
+from .. import Series
 
 
-def test_str_split(setup):
-    s = pd.Series(["A_Str_Series"])
+def test_str_accessor(setup):
+    # xs being a xorbits.pandas.core.Series instance
+    s = pd.Series(["A_Str"])
     xs = xpd.Series(s)
-
+    assert isinstance(xs, Series)
     pd.testing.assert_series_equal(s.str.split("_"), xs.str.split("_").to_pandas())
+
+    # xs being a xorbits.core.data.DataRef instance
+    s = s + "_Series"
+    xs = xs + "_Series"
+    assert not isinstance(xs, Series)
+    assert isinstance(xs, DataRef)
+    pd.testing.assert_series_equal(s.str.split("_"), xs.str.split("_").to_pandas())
+
+
+def test_dt_accessor(setup):
+    import numpy as np
+
+    # xs being a xorbits.pandas.core.Series instance
+    a = np.arange(
+        np.datetime64("2000-01-01"), np.datetime64("2000-01-03"), dtype=np.datetime64
+    )
+    s = pd.Series(a)
+    xs = xpd.Series(a)
+    assert isinstance(xs, Series)
+    pd.testing.assert_series_equal(s.dt.year, xs.dt.year.to_pandas())
+
+    # xs being a xorbits.core.data.DataRef instance
+    s = pd.concat((s, s))
+    xs = xpd.concat((xs, xs))
+    assert not isinstance(xs, Series)
+    assert isinstance(xs, DataRef)
+    pd.testing.assert_series_equal(s.dt.year, xs.dt.year.to_pandas())
 
 
 def test_class_docstring():


### PR DESCRIPTION
To reproduce:
```python

# xs being a xorbits.pandas.core.Series instance
s = pd.Series(["A_Str"])
xs = xpd.Series(s)
assert isinstance(xs, Series)
pd.testing.assert_series_equal(s.str.split("_"), xs.str.split("_").to_pandas())

# xs being a xorbits.core.data.DataRef instance
s = s + "_Series"
xs = xs + "_Series"
assert not isinstance(xs, Series)
assert isinstance(xs, DataRef)
pd.testing.assert_series_equal(s.str.split("_"), xs.str.split("_").to_pandas())
```