### PR TITLE
BLD: Trigger docker cd manually

### DIFF
--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -61,14 +62,7 @@ jobs:
             if [[ -n "$GIT_TAG" ]]; then
               export IMAGE_TAG="$GIT_TAG"
             else
-              echo ""
               git checkout $branch
-              git log --pretty=format:"%h - %an, %cd : %s" --since=25.hours
-              # consider schedule delay of Github Actions, some margin needed.
-              if [[ ! "$(git log --since=25.hours)" ]]; then
-                echo "No recent commits on branch $branch found, will skip building image."
-                continue
-              fi
               export IMAGE_TAG="nightly-$branch"
             fi
             docker build -t "xprobe/xorbits:base-py$PY_VERSION" --progress=plain -f python/xorbits/deploy/docker/Dockerfile.base . --build-arg PYTHON_VERSION=$PY_VERSION


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
1. Some PR changes docker file but want to manually trigger docker cd to update the base image to pass the K8s UT without waiting until the next day.
Now you can trigger docker cd manually.
Reference: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

2. Even if there are no commits on a certain day, the image is still built, so that some package version update problems can be discovered in time.

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
