### PR TITLE
BUG: dead lock in transfer actor in the case of GPU

### DIFF
--- a/python/xorbits/_mars/services/storage/core.py
+++ b/python/xorbits/_mars/services/storage/core.py
@@ -93,6 +93,12 @@ class WrappedStorageFileObject(AioFileObject):
         self._file.close()
 
     async def close(self):
+        logger.debug(
+            "Writer closed for %s, %s on %s",
+            self._session_id,
+            self._data_key,
+            self._data_manager.address,
+        )
         self._file.close()
         if self._object_id is None:
             # for some backends like vineyard,
@@ -322,6 +328,9 @@ class DataManagerActor(mo.Actor):
         level: StorageLevel,
         band_name: str,
     ):
+        logger.debug(
+            "Deleting %s, %s from %s, %s", session_id, data_key, level, band_name
+        )
         if (session_id, data_key) in self._data_key_to_infos:
             self._data_info_list[level, band_name].pop((session_id, data_key))
             self._spill_strategy[level, band_name].record_delete_info(

--- a/python/xorbits/_mars/services/storage/handler.py
+++ b/python/xorbits/_mars/services/storage/handler.py
@@ -546,6 +546,8 @@ class StorageHandlerActor(mo.Actor):
             # no data to be transferred
             return
 
+        logger.debug("Writers have been opened for %s", data_keys)
+
         sender_ref: mo.ActorRefType[SenderManagerActor] = await mo.actor_ref(
             address=remote_band[0], uid=SenderManagerActor.gen_uid(remote_band[1])
         )
@@ -553,8 +555,7 @@ class StorageHandlerActor(mo.Actor):
             session_id,
             data_keys,
             is_transferring_list,
-            self._data_manager_ref.address,
-            fetch_band_name,
+            (self._data_manager_ref.address, fetch_band_name),
         )
         logger.debug("Finish fetching %s from band %s", data_keys, remote_band)
 

--- a/python/xorbits/_mars/services/storage/handler.py
+++ b/python/xorbits/_mars/services/storage/handler.py
@@ -611,9 +611,16 @@ class StorageHandlerActor(mo.Actor):
         sender_ref: mo.ActorRefType[SenderManagerActor] = await mo.actor_ref(
             address=remote_band[0], uid=SenderManagerActor.gen_uid(remote_band[1])
         )
+
+        open_reader_tasks = []
+        for data_key in data_keys:
+            open_reader_tasks.append(self.open_reader.delay(session_id, data_key))
+        readers = await self.open_reader.batch(*open_reader_tasks)
+
         await sender_ref.send_batch_data(
             session_id,
             data_keys,
+            readers,
             is_transferring_list,
             (self._data_manager_ref.address, fetch_band_name),
         )

--- a/python/xorbits/_mars/services/storage/handler.py
+++ b/python/xorbits/_mars/services/storage/handler.py
@@ -535,12 +535,72 @@ class StorageHandlerActor(mo.Actor):
 
         logger.debug("Begin to fetch %s from band %s", data_keys, remote_band)
 
+        remote_data_manager_ref: mo.ActorRefType[DataManagerActor] = await mo.actor_ref(
+            address=remote_band[0], uid=DataManagerActor.default_uid()
+        )
+
+        logger.debug("Getting actual keys for %s", data_keys)
+        tasks = []
+        for key in data_keys:
+            tasks.append(remote_data_manager_ref.get_store_key.delay(session_id, key))
+        data_keys = await remote_data_manager_ref.get_store_key.batch(*tasks)
+        data_keys = list(set(data_keys))
+
+        logger.debug("Getting sub infos for %s", data_keys)
+        sub_infos = await remote_data_manager_ref.get_sub_infos.batch(
+            *[
+                remote_data_manager_ref.get_sub_infos.delay(session_id, key)
+                for key in data_keys
+            ]
+        )
+
+        get_infos = []
+        pin_tasks = []
+        for data_key in data_keys:
+            get_infos.append(
+                remote_data_manager_ref.get_data_info.delay(
+                    session_id, data_key, remote_band[1], error
+                )
+            )
+            pin_tasks.append(
+                remote_data_manager_ref.pin.delay(
+                    session_id, data_key, remote_band[1], error
+                )
+            )
+
+        logger.debug("Pining %s", data_keys)
+        await remote_data_manager_ref.pin.batch(*pin_tasks)
+        logger.debug("Getting data infos for %s", data_keys)
+        infos = await remote_data_manager_ref.get_data_info.batch(*get_infos)
+
+        filtered = [
+            (data_info, data_key)
+            for data_info, data_key in zip(infos, data_keys)
+            if data_info is not None
+        ]
+        if filtered:
+            infos, data_keys = zip(*filtered)
+        else:  # pragma: no cover
+            # no data to be transferred
+            return []
+        data_sizes = [info.store_size for info in infos]
+
+        if level is None:
+            level = infos[0].level
+
+        logger.debug("Requesting quota for %s", data_keys)
+        await self.request_quota_with_spill(level, sum(data_sizes))
+
         receiver_ref: mo.ActorRefType[ReceiverManagerActor] = await mo.actor_ref(
             address=self.address,
             uid=ReceiverManagerActor.gen_uid(fetch_band_name),
         )
         is_transferring_list = await receiver_ref.open_writers(
-            session_id, data_keys, level, remote_band, error
+            session_id,
+            data_keys,
+            data_sizes,
+            sub_infos,
+            level,
         )
         if not is_transferring_list:
             # no data to be transferred

--- a/python/xorbits/_mars/services/storage/tests/test_transfer.py
+++ b/python/xorbits/_mars/services/storage/tests/test_transfer.py
@@ -17,17 +17,18 @@ import asyncio
 import os
 import sys
 import tempfile
-from typing import List, Union
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
 import pytest
 import xoscar as mo
 from xoscar.backends.allocate_strategy import IdleLabel
+from xoscar.errors import NoIdleSlot
 
 from ....oscar import create_actor_pool
 from ....storage import StorageLevel
-from ..core import DataManagerActor, StorageManagerActor, StorageQuotaActor
+from ..core import StorageManagerActor, StorageQuotaActor
 from ..errors import DataNotExist
 from ..handler import StorageHandlerActor
 from ..transfer import ReceiverManagerActor, SenderManagerActor
@@ -62,9 +63,21 @@ async def actor_pools():
         await worker_pool_2.stop()
 
 
+async def _get_io_address(pool):
+    pool_config = (await mo.get_pool_config(pool.external_address)).as_dict()
+    return [
+        v["external_address"][0]
+        for k, v in pool_config["pools"].items()
+        if v["label"] == "io"
+    ][0]
+
+
 @pytest.fixture
 async def create_actors(actor_pools):
     worker_pool_1, worker_pool_2 = actor_pools
+
+    io1 = await _get_io_address(worker_pool_1)
+    io2 = await _get_io_address(worker_pool_2)
 
     tmp_dir = tempfile.mkdtemp()
     storage_configs = {"shared_memory": {}, "disk": {"root_dirs": f"{tmp_dir}"}}
@@ -82,7 +95,39 @@ async def create_actors(actor_pools):
         uid=StorageManagerActor.default_uid(),
         address=worker_pool_2.external_address,
     )
-    yield worker_pool_1.external_address, worker_pool_2.external_address
+    yield worker_pool_1.external_address, worker_pool_2.external_address, io1, io2
+    try:
+        await mo.destroy_actor(manager_ref1)
+        await mo.destroy_actor(manager_ref2)
+    except FileNotFoundError:
+        pass
+    assert not os.path.exists(tmp_dir)
+
+
+@pytest.fixture
+async def create_actors_mock(actor_pools):
+    worker_pool_1, worker_pool_2 = actor_pools
+
+    io1 = await _get_io_address(worker_pool_1)
+    io2 = await _get_io_address(worker_pool_2)
+
+    tmp_dir = tempfile.mkdtemp()
+    storage_configs = {"shared_memory": {}, "disk": {"root_dirs": f"{tmp_dir}"}}
+
+    manager_ref1 = await mo.create_actor(
+        MockStorageManagerActor,
+        storage_configs,
+        uid=MockStorageManagerActor.default_uid(),
+        address=worker_pool_1.external_address,
+    )
+
+    manager_ref2 = await mo.create_actor(
+        MockStorageManagerActor,
+        storage_configs,
+        uid=MockStorageManagerActor.default_uid(),
+        address=worker_pool_2.external_address,
+    )
+    yield worker_pool_1.external_address, worker_pool_2.external_address, io1, io2
     try:
         await mo.destroy_actor(manager_ref1)
         await mo.destroy_actor(manager_ref2)
@@ -93,16 +138,16 @@ async def create_actors(actor_pools):
 
 @pytest.mark.asyncio
 async def test_simple_transfer(create_actors):
-    worker_address_1, worker_address_2 = create_actors
+    worker_address_1, worker_address_2, io1, io2 = create_actors
 
     data1 = np.random.rand(100, 100)
     data2 = pd.DataFrame(np.random.randint(0, 100, (500, 10)))
 
-    storage_handler1 = await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_1
+    storage_handler1: mo.ActorRefType[StorageHandlerActor] = await mo.actor_ref(
+        uid=StorageHandlerActor.gen_uid("numa-0"), address=io1
     )
-    storage_handler2 = await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_2
+    storage_handler2: mo.ActorRefType[StorageHandlerActor] = await mo.actor_ref(
+        uid=StorageHandlerActor.gen_uid("numa-0"), address=io2
     )
 
     for level in (StorageLevel.MEMORY, StorageLevel.DISK):
@@ -111,65 +156,26 @@ async def test_simple_transfer(create_actors):
         await storage_handler1.put(session_id, "data_key2", data2, level)
         await storage_handler2.put(session_id, "data_key3", data2, level)
 
-    receiver_actor: mo.ActorRefType[ReceiverManagerActor] = await mo.actor_ref(
-        address=worker_address_2, uid=ReceiverManagerActor.gen_uid("numa-0")
-    )
-    sender_actor: mo.ActorRefType[SenderManagerActor] = await mo.actor_ref(
-        address=worker_address_1, uid=SenderManagerActor.gen_uid("numa-0")
-    )
+        await storage_handler2.fetch_via_transfer(
+            session_id,
+            ["data_key1", "data_key2"],
+            level,
+            (io1, "numa-0"),
+            "numa-0",
+            "raise",
+        )
 
-    is_transferring = await receiver_actor.open_writers(
-        session_id,
-        ["data_key1", "data_key2"],
-        StorageLevel.MEMORY,
-        (sender_actor.address, "numa-0"),
-        "raise",
-    )
+        get_data1 = await storage_handler2.get(session_id, "data_key1")
+        np.testing.assert_array_equal(data1, get_data1)
 
-    # send data to worker2 from worker1
-    await sender_actor.send_batch_data(
-        session_id,
-        ["data_key1"],
-        is_transferring,
-        (receiver_actor.address, "numa-0"),
-        block_size=1000,
-    )
+        get_data2 = await storage_handler2.get(session_id, "data_key2")
+        pd.testing.assert_frame_equal(data2, get_data2)
 
-    await sender_actor.send_batch_data(
-        session_id,
-        ["data_key2"],
-        is_transferring,
-        (receiver_actor.address, "numa-0"),
-        block_size=1000,
-    )
-
-    get_data1 = await storage_handler2.get(session_id, "data_key1")
-    np.testing.assert_array_equal(data1, get_data1)
-
-    get_data2 = await storage_handler2.get(session_id, "data_key2")
-    pd.testing.assert_frame_equal(data2, get_data2)
-
-    # send data to worker1 from worker2
-    receiver_actor: mo.ActorRefType[ReceiverManagerActor] = await mo.actor_ref(
-        address=worker_address_1, uid=ReceiverManagerActor.gen_uid("numa-0")
-    )
-    sender_actor: mo.ActorRefType[SenderManagerActor] = await mo.actor_ref(
-        address=worker_address_2, uid=SenderManagerActor.gen_uid("numa-0")
-    )
-
-    is_transferring = await receiver_actor.open_writers(
-        session_id,
-        ["data_key3"],
-        StorageLevel.MEMORY,
-        (sender_actor.address, "numa-0"),
-        "raise",
-    )
-
-    await sender_actor.send_batch_data(
-        session_id, ["data_key3"], is_transferring, (receiver_actor.address, "numa-0")
-    )
-    get_data3 = await storage_handler1.get(session_id, "data_key3")
-    pd.testing.assert_frame_equal(data2, get_data3)
+        await storage_handler1.fetch_via_transfer(
+            session_id, ["data_key3"], level, (io2, "numa-0"), "numa-0", "raise"
+        )
+        get_data3 = await storage_handler1.get(session_id, "data_key3")
+        pd.testing.assert_frame_equal(data2, get_data3)
 
 
 # test for cancelling happens when writing
@@ -181,12 +187,12 @@ class MockSenderManagerActor(SenderManagerActor):
     @staticmethod
     async def get_receiver_ref(address: str, band_name: str):
         return await mo.actor_ref(
-            address=address, uid=MockReceiverManagerActor.default_uid()
+            address=address, uid=MockReceiverManagerActor.gen_uid(band_name)
         )
 
     async def _copy_to_receiver(
         self,
-        receiver_ref: mo.ActorRefType["ReceiverManagerActor"],
+        receiver_ref: mo.ActorRefType["MockReceiverManagerActor"],
         local_buffers: List,
         remote_buffers: List,
         session_id: str,
@@ -204,35 +210,73 @@ class MockSenderManagerActor(SenderManagerActor):
         )
 
 
-# test for cancelling happens when creating writer
-class MockReceiverManagerActor2(ReceiverManagerActor):
-    async def create_writers(
-        self, session_id, data_keys, data_sizes, level, sub_infos, band_name
-    ):
-        await asyncio.sleep(3)
-        return await super().create_writers(
-            session_id, data_keys, data_sizes, level, sub_infos, band_name
-        )
-
-
-class MockSenderManagerActor2(SenderManagerActor):
-    @staticmethod
-    async def get_receiver_ref(address: str, band_name: str):
+class MockStorageHandlerActor(StorageHandlerActor):
+    async def get_receive_manager_ref(self, band_name: str):
         return await mo.actor_ref(
-            address=address, uid=MockReceiverManagerActor2.default_uid()
+            address=self.address,
+            uid=MockReceiverManagerActor.gen_uid(band_name),
         )
+
+    @staticmethod
+    async def get_send_manager_ref(address: str, band: str):
+        return await mo.actor_ref(
+            address=address, uid=MockSenderManagerActor.gen_uid(band)
+        )
+
+
+class MockStorageManagerActor(StorageManagerActor):
+    def __init__(
+        self, storage_configs: Dict, transfer_block_size: int = None, **kwargs
+    ):
+        super().__init__(storage_configs, transfer_block_size, **kwargs)
+        self._handler_cls = MockStorageHandlerActor
+
+    async def _create_transfer_actors(self):
+        default_band_name = "numa-0"
+        sender_strategy = IdleLabel("io", "sender")
+        receiver_strategy = IdleLabel("io", "receiver")
+        handler_strategy = IdleLabel("io", "handler")
+        while True:
+            try:
+                handler_ref = await mo.create_actor(
+                    MockStorageHandlerActor,
+                    self._init_params[default_band_name],
+                    self._data_manager,
+                    self._spill_managers[default_band_name],
+                    self._quotas[default_band_name],
+                    default_band_name,
+                    uid=MockStorageHandlerActor.gen_uid(default_band_name),
+                    address=self.address,
+                    allocate_strategy=handler_strategy,
+                )
+                await mo.create_actor(
+                    MockSenderManagerActor,
+                    data_manager_ref=self._data_manager,
+                    storage_handler_ref=handler_ref,
+                    uid=MockSenderManagerActor.gen_uid(default_band_name),
+                    address=self.address,
+                    allocate_strategy=sender_strategy,
+                )
+
+                await mo.create_actor(
+                    MockReceiverManagerActor,
+                    self._quotas[default_band_name],
+                    handler_ref,
+                    address=self.address,
+                    uid=MockReceiverManagerActor.gen_uid(default_band_name),
+                    allocate_strategy=receiver_strategy,
+                )
+            except NoIdleSlot:
+                break
 
 
 @pytest.mark.parametrize(
     "mock_sender_cls, mock_receiver_cls",
-    [
-        (MockSenderManagerActor, MockReceiverManagerActor),
-        (MockSenderManagerActor2, MockReceiverManagerActor2),
-    ],
+    [(MockSenderManagerActor, MockReceiverManagerActor)],
 )
 @pytest.mark.asyncio
-async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls):
-    worker_address_1, worker_address_2 = create_actors
+async def test_cancel_transfer(create_actors_mock, mock_sender_cls, mock_receiver_cls):
+    _, _, io1, io2 = create_actors_mock
 
     session_id = "mock_session"
     quota_refs = {
@@ -240,33 +284,15 @@ async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls
             StorageQuotaActor,
             StorageLevel.MEMORY,
             5 * 1024 * 1024,
-            address=worker_address_2,
+            address=io2,
             uid=StorageQuotaActor.gen_uid("numa-0", StorageLevel.MEMORY),
         )
     }
-    data_manager_ref = await mo.actor_ref(
-        uid=DataManagerActor.default_uid(), address=worker_address_1
-    )
     storage_handler1 = await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_1
+        uid=MockStorageHandlerActor.gen_uid("numa-0"), address=io1
     )
     storage_handler2 = await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_2
-    )
-
-    sender_actor: mo.ActorRefType[SenderManagerActor] = await mo.create_actor(
-        mock_sender_cls,
-        data_manager_ref=data_manager_ref,
-        uid=mock_sender_cls.default_uid(),
-        address=worker_address_1,
-        allocate_strategy=IdleLabel("io", "mock_sender_cls"),
-    )
-    receiver_actor: mo.ActorRefType[ReceiverManagerActor] = await mo.create_actor(
-        mock_receiver_cls,
-        quota_refs,
-        uid=mock_receiver_cls.default_uid(),
-        address=worker_address_2,
-        allocate_strategy=IdleLabel("io", "mock_receiver_cls"),
+        uid=MockStorageHandlerActor.gen_uid("numa-0"), address=io2
     )
 
     data1 = np.random.rand(10, 10)
@@ -276,31 +302,18 @@ async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls
 
     used_before = (await quota_refs[StorageLevel.MEMORY].get_quota())[1]
 
-    async def transfer(
-        data_keys: List[Union[str, tuple]],
-        sender: mo.ActorRefType[SenderManagerActor],
-        receiver: mo.ActorRefType[ReceiverManagerActor],
-    ):
-        is_transferring_list = await receiver.open_writers(
+    transfer_task = asyncio.create_task(
+        storage_handler2.fetch_via_transfer(
             session_id,
-            data_keys,
+            ["data_key1"],
             StorageLevel.MEMORY,
-            (sender.address, "numa-0"),
+            (io1, "numa-0"),
+            "numa-0",
             "raise",
         )
-        assert len(is_transferring_list) > 0
-        await sender.send_batch_data(
-            session_id,
-            data_keys,
-            is_transferring_list,
-            (receiver.address, "numa-0"),
-        )
-
-    transfer_task = asyncio.create_task(
-        transfer(["data_key1"], sender_actor, receiver_actor)
     )
 
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(1)
     transfer_task.cancel()
 
     with pytest.raises(asyncio.CancelledError):
@@ -313,7 +326,14 @@ async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls
         await storage_handler2.get(session_id, "data_key1")
 
     transfer_task = asyncio.create_task(
-        transfer(["data_key1"], sender_actor, receiver_actor)
+        storage_handler2.fetch_via_transfer(
+            session_id,
+            ["data_key1"],
+            StorageLevel.MEMORY,
+            (io1, "numa-0"),
+            "numa-0",
+            "raise",
+        )
     )
     await transfer_task
     get_data = await storage_handler2.get(session_id, "data_key1")
@@ -322,12 +342,26 @@ async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls
     # cancel when fetch the same data Simultaneously
     if mock_sender_cls is MockSenderManagerActor:
         transfer_task1 = asyncio.create_task(
-            transfer(["data_key2"], sender_actor, receiver_actor)
+            storage_handler2.fetch_via_transfer(
+                session_id,
+                ["data_key1"],
+                StorageLevel.MEMORY,
+                (io1, "numa-0"),
+                "numa-0",
+                "raise",
+            )
         )
         transfer_task2 = asyncio.create_task(
-            transfer(["data_key2"], sender_actor, receiver_actor)
+            storage_handler2.fetch_via_transfer(
+                session_id,
+                ["data_key2"],
+                StorageLevel.MEMORY,
+                (io1, "numa-0"),
+                "numa-0",
+                "raise",
+            )
         )
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         transfer_task1.cancel()
         with pytest.raises(asyncio.CancelledError):
             await transfer_task1
@@ -338,37 +372,37 @@ async def test_cancel_transfer(create_actors, mock_sender_cls, mock_receiver_cls
 
 @pytest.mark.asyncio
 async def test_transfer_same_data(create_actors):
-    worker_address_1, worker_address_2 = create_actors
+    worker_address_1, worker_address_2, io1, io2 = create_actors
 
     session_id = "mock_session"
     data1 = np.random.rand(100, 100)
     storage_handler1 = await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_1
+        uid=StorageHandlerActor.gen_uid("numa-0"), address=io1
     )
-    await mo.actor_ref(
-        uid=StorageHandlerActor.gen_uid("numa-0"), address=worker_address_2
+    storage_handler2 = await mo.actor_ref(
+        uid=StorageHandlerActor.gen_uid("numa-0"), address=io2
     )
 
     await storage_handler1.put(session_id, "data_key1", data1, StorageLevel.MEMORY)
 
-    receiver_actor: mo.ActorRefType[ReceiverManagerActor] = await mo.actor_ref(
-        address=worker_address_2, uid=ReceiverManagerActor.gen_uid("numa-0")
-    )
-    task1 = receiver_actor.open_writers(
+    task1 = storage_handler2.fetch_via_transfer(
         session_id,
         ["data_key1"],
         StorageLevel.MEMORY,
-        (worker_address_1, "numa-0"),
+        (io1, "numa-0"),
+        "numa-0",
         "raise",
     )
-    task2 = receiver_actor.open_writers(
+    task2 = storage_handler2.fetch_via_transfer(
         session_id,
         ["data_key1"],
         StorageLevel.MEMORY,
-        (worker_address_1, "numa-0"),
+        (io1, "numa-0"),
+        "numa-0",
         "raise",
     )
 
-    results = await asyncio.gather(task1, task2)
-    assert [False] in results
-    assert [True] in results
+    await asyncio.gather(task1, task2)
+
+    get_data = await storage_handler2.get(session_id, "data_key1")
+    np.testing.assert_array_equal(get_data, data1)

--- a/python/xorbits/_mars/services/storage/tests/test_transfer_gpu.py
+++ b/python/xorbits/_mars/services/storage/tests/test_transfer_gpu.py
@@ -28,7 +28,6 @@ from ....tests.core import require_cudf, require_cupy
 from ....utils import lazy_import
 from ..core import StorageManagerActor
 from ..handler import StorageHandlerActor
-from ..transfer import SenderManagerActor
 
 cupy = lazy_import("cupy")
 cudf = lazy_import("cudf")
@@ -109,7 +108,7 @@ def _generate_band_scheme():
     gpu_bands = []
     if gpu_counts:
         gpu_bands.extend([(f"gpu-{i}", f"gpu-{i+1}") for i in range(gpu_counts - 1)])
-    bands = [("numa-0", "numa-0"), ("gpu-0", "gpu-0")]
+    bands = [("gpu-0", "gpu-0")]
     bands.extend(gpu_bands)
     schemes = [(None, None), ("ucx", "ucx"), (None, "ucx"), ("ucx", None)]
     for band in bands:
@@ -137,7 +136,7 @@ async def test_simple_transfer(create_actors):
     storage_handler1 = await mo.actor_ref(
         uid=StorageHandlerActor.gen_uid(bands[0]), address=worker_address_1
     )
-    storage_handler2 = await mo.actor_ref(
+    storage_handler2: mo.ActorRefType[StorageHandlerActor] = await mo.actor_ref(
         uid=StorageHandlerActor.gen_uid(bands[1]), address=worker_address_2
     )
 
@@ -146,27 +145,13 @@ async def test_simple_transfer(create_actors):
     await storage_handler1.put(session_id, "data_key2", data2, storage_level)
     await storage_handler2.put(session_id, "data_key3", data2, storage_level)
 
-    sender_actor = await mo.actor_ref(
-        address=worker_address_1, uid=SenderManagerActor.gen_uid(bands[0])
-    )
-
-    # send data to worker2 from worker1
-    await sender_actor.send_batch_data(
+    await storage_handler2.fetch_via_transfer(
         session_id,
-        ["data_key1"],
-        worker_address_2,
+        ["data_key1", "data_key2"],
         storage_level,
-        block_size=1000,
-        band_name=bands[1],
-    )
-
-    await sender_actor.send_batch_data(
-        session_id,
-        ["data_key2"],
-        worker_address_2,
-        storage_level,
-        block_size=1000,
-        band_name=bands[1],
+        (worker_address_1, bands[0]),
+        bands[1],
+        "raise",
     )
 
     get_data1 = await storage_handler2.get(session_id, "data_key1")
@@ -175,18 +160,15 @@ async def test_simple_transfer(create_actors):
     get_data2 = await storage_handler2.get(session_id, "data_key2")
     xpd.testing.assert_frame_equal(data2, get_data2)
 
-    # send data to worker1 from worker2
-    sender_actor = await mo.actor_ref(
-        address=worker_address_2, uid=SenderManagerActor.gen_uid(bands[1])
-    )
-    await sender_actor.send_batch_data(
+    await storage_handler1.fetch_via_transfer(
         session_id,
         ["data_key3"],
-        worker_address_1,
         storage_level,
-        block_size=1000,
-        band_name=bands[0],
+        (worker_address_2, bands[1]),
+        bands[0],
+        "raise",
     )
+
     get_data3 = await storage_handler1.get(session_id, "data_key3")
     xpd.testing.assert_frame_equal(data2, get_data3)
 
@@ -212,29 +194,35 @@ async def test_transfer_same_data(create_actors):
     )
 
     await storage_handler1.put(session_id, "data_key1", data1, storage_level)
-    sender_actor = await mo.actor_ref(
-        address=worker_address_1, uid=SenderManagerActor.gen_uid(bands[0])
+
+    storage_handler2.fetch_via_transfer(
+        session_id,
+        ["data_key1"],
+        storage_level,
+        (worker_address_1, bands[0]),
+        bands[1],
+        "raise",
     )
 
     # send data to worker2 from worker1
     task1 = asyncio.create_task(
-        sender_actor.send_batch_data(
+        storage_handler2.fetch_via_transfer(
             session_id,
             ["data_key1"],
-            worker_address_2,
             storage_level,
-            block_size=1000,
-            band_name=bands[1],
+            (worker_address_1, bands[0]),
+            bands[1],
+            "raise",
         )
     )
     task2 = asyncio.create_task(
-        sender_actor.send_batch_data(
+        storage_handler2.fetch_via_transfer(
             session_id,
             ["data_key1"],
-            worker_address_2,
             storage_level,
-            block_size=1000,
-            band_name=bands[1],
+            (worker_address_1, bands[0]),
+            bands[1],
+            "raise",
         )
     )
     await asyncio.gather(task1, task2)

--- a/python/xorbits/_mars/services/storage/transfer.py
+++ b/python/xorbits/_mars/services/storage/transfer.py
@@ -333,70 +333,13 @@ class ReceiverManagerActor(mo.StatelessActor):
         session_id: str,
         data_keys: List[str],
         data_sizes: List[int],
-        sub_infos: List,
+        sub_infos,
         level: StorageLevel,
-        band_name: str,
-        remote_band,
-        error
+        band_name
     ) -> List[bool]:
         logger.debug("Start opening writers for %s", data_keys)
 
-        remote_data_manager_ref: mo.ActorRefType[DataManagerActor] = await mo.actor_ref(
-            address=remote_band[0], uid=DataManagerActor.default_uid()
-        )
-
-        logger.debug("Getting actual keys for %s", data_keys)
-        tasks = []
-        for key in data_keys:
-            tasks.append(remote_data_manager_ref.get_store_key.delay(session_id, key))
-        data_keys = await remote_data_manager_ref.get_store_key.batch(*tasks)
-        data_keys = list(set(data_keys))
-
-        logger.debug("Getting sub infos for %s", data_keys)
-        sub_infos = await remote_data_manager_ref.get_sub_infos.batch(
-            *[
-                remote_data_manager_ref.get_sub_infos.delay(session_id, key)
-                for key in data_keys
-            ]
-        )
-
-        get_infos = []
-        pin_tasks = []
-        for data_key in data_keys:
-            get_infos.append(
-                remote_data_manager_ref.get_data_info.delay(
-                    session_id, data_key, remote_band[1], error
-                )
-            )
-            pin_tasks.append(
-                remote_data_manager_ref.pin.delay(
-                    session_id, data_key, remote_band[1], error
-                )
-            )
-
-        logger.debug("Pining %s", data_keys)
-        await remote_data_manager_ref.pin.batch(*pin_tasks)
-        logger.debug("Getting data infos for %s", data_keys)
-        infos = await remote_data_manager_ref.get_data_info.batch(*get_infos)
-
-        filtered = [
-            (data_info, data_key)
-            for data_info, data_key in zip(infos, data_keys)
-            if data_info is not None
-        ]
-        if filtered:
-            infos, data_keys = zip(*filtered)
-        else:  # pragma: no cover
-            # no data to be transferred
-            return []
-        data_sizes = [info.store_size for info in infos]
-
-        if level is None:
-            level = infos[0].level
-
         async with self._lock:
-            logger.debug("Requesting quota for %s", data_keys)
-            await self._storage_handler.request_quota_with_spill(level, sum(data_sizes))
             logger.debug("Opening writers for %s", data_keys)
             future = asyncio.create_task(
                 self.create_writers(

--- a/python/xorbits/_mars/services/storage/transfer.py
+++ b/python/xorbits/_mars/services/storage/transfer.py
@@ -173,10 +173,14 @@ class SenderManagerActor(mo.StatelessActor):
         ] = await self.get_receiver_ref(remote_band[0], remote_band[1])
 
         if to_send_keys:
+            logger.debug("Start sending %s", to_send_keys)
             block_size = block_size or self._transfer_block_size
             await self._send_data(receiver_ref, session_id, to_send_keys, block_size)
+            logger.debug("Done sending %s", to_send_keys)
         if to_wait_keys:
+            logger.debug("Start waiting %s", to_wait_keys)
             await receiver_ref.wait_transfer_done(session_id, to_wait_keys)
+            logger.debug("Done waiting %s", to_wait_keys)
         unpin_tasks = []
         for data_key in data_keys:
             unpin_tasks.append(

--- a/python/xorbits/_mars/services/storage/transfer.py
+++ b/python/xorbits/_mars/services/storage/transfer.py
@@ -394,9 +394,10 @@ class ReceiverManagerActor(mo.StatelessActor):
         if level is None:
             level = infos[0].level
 
-        logger.debug("Opening writers for %s", data_keys)
         async with self._lock:
+            logger.debug("Requesting quota for %s", data_keys)
             await self._storage_handler.request_quota_with_spill(level, sum(data_sizes))
+            logger.debug("Opening writers for %s", data_keys)
             future = asyncio.create_task(
                 self.create_writers(
                     session_id, data_keys, data_sizes, level, sub_infos, band_name

--- a/python/xorbits/_mars/services/storage/transfer.py
+++ b/python/xorbits/_mars/services/storage/transfer.py
@@ -317,6 +317,7 @@ class ReceiverManagerActor(mo.StatelessActor):
                 being_processed.append(True)
                 self._writing_infos[(session_id, data_key)].ref_counts += 1
         if tasks:
+            logger.debug("Executing open_writer.batch")
             writers = await self._storage_handler.open_writer.batch(
                 *tuple(tasks.values())
             )

--- a/python/xorbits/_mars/services/storage/transfer.py
+++ b/python/xorbits/_mars/services/storage/transfer.py
@@ -17,9 +17,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from io import UnsupportedOperation
-from typing import Any, Dict, List, Union
-from typing import TYPE_CHECKING, Dict, List
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 
 import xoscar as mo
 from xoscar.core import BufferRef
@@ -30,10 +28,6 @@ from ...typing import BandType
 from ...utils import dataslots
 from .core import DataManagerActor, WrappedStorageFileObject
 from .handler import StorageHandlerActor
-
-if TYPE_CHECKING:
-    from ...storage.core import StorageFileObject
-
 
 DEFAULT_TRANSFER_BLOCK_SIZE = 4 * 1024**2
 
@@ -159,7 +153,6 @@ class SenderManagerActor(mo.StatelessActor):
         self,
         session_id: str,
         data_keys: List[str],
-        readers: List["StorageFileObject"],
         is_transferring_list: List[bool],
         remote_band: BandType,
         block_size: int = None,
@@ -180,11 +173,9 @@ class SenderManagerActor(mo.StatelessActor):
         ] = await self.get_receiver_ref(remote_band[0], remote_band[1])
 
         if to_send_keys:
-            logger.debug("Start sending %s", to_send_keys)
+            logger.debug("Start sending %s to %s", to_send_keys, receiver_ref.address)
             block_size = block_size or self._transfer_block_size
-            await self._send_data(
-                receiver_ref, readers, session_id, to_send_keys, block_size
-            )
+            await self._send_data(receiver_ref, session_id, to_send_keys, block_size)
             logger.debug("Done sending %s", to_send_keys)
         if to_wait_keys:
             logger.debug("Start waiting %s", to_wait_keys)

--- a/python/xorbits/_mars/storage/cuda.py
+++ b/python/xorbits/_mars/storage/cuda.py
@@ -67,7 +67,10 @@ class CudaFileObject:
         from rmm import DeviceBuffer
 
         self._buffers = [
-            _convert_to_cupy_ndarray(DeviceBuffer(size=size)) for size in sizes
+            cupy.ndarray(shape=0, dtype="u1")
+            if size == 0
+            else _convert_to_cupy_ndarray(DeviceBuffer(size=size))
+            for size in sizes
         ]
 
     @property
@@ -96,7 +99,10 @@ class CudaFileObject:
                 self._buffers.append(buf.astype("u1", copy=False))
                 buffer_types.append(["cuda", buf.size])
             elif isinstance(buf, Buffer):
-                self._buffers.append(_convert_to_cupy_ndarray(buf))
+                if buf.size == 0:
+                    self._buffers.append(cupy.ndarray(shape=0, dtype="u1"))
+                else:
+                    self._buffers.append(_convert_to_cupy_ndarray(buf))
                 buffer_types.append(["cuda", buf.size])
             else:
                 size = getattr(buf, "size", len(buf))


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
The current implementation of the transfer function leads to a deadlock when executing Xorbits on multiple GPUs. The issue arises from the `StorageHandlerActor.fetch_batch` function, which invokes `SenderManagerActor.send_batch_data` and subsequently calls `StorageHandlerActor.request_quota_with_spill`. Due to the locking mechanism within the StorageHandlerActor method call, a deadlock arises.


UPDATE:
- fix dead lock on GPU
- fix GPU buffer size 0 issue
- known issue: when ``ucx`` is enabled, performance is not improved on multi GPUs.
- known issue: too many actor calls in this implement. May lead to performance down.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
