### PR TITLE
BUG: Fix Unable to build documentation with Chinese

### DIFF
--- a/doc/source/development/contributing_documentation.rst
+++ b/doc/source/development/contributing_documentation.rst
@@ -137,7 +137,7 @@ Then you can find the HTML output in the folder ``doc/build/html/``.
 
 To build the docs in Chinese, run::
 
-   make html_zh_cn
+   sphinx-build -b html -D language=zh_CN source build/html_zh_cn
 
 Then you can find the HTML output in the folder ``doc/build/html_zh_cn/``.
 


### PR DESCRIPTION
## What do these changes do?
Fix Unable to build documentation with Chinese
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #517 

## outcome
![image](https://github.com/xprobe-inc/xorbits/assets/82318611/dd9dc238-47d1-4555-9efe-b335461de4f0)
![image](https://github.com/xprobe-inc/xorbits/assets/82318611/4a0b342a-7f6a-4c26-9836-b12cab472ba6)

