### PR TITLE
BUG: Fix importing learn.contrib is slow

### DIFF
--- a/python/xorbits/_mars/learn/__init__.py
+++ b/python/xorbits/_mars/learn/__init__.py
@@ -12,16 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from . import cluster, ensemble, neighbors, preprocessing, proxima, utils
-
-# register operands
-# import torch first, or some issue emerges,
-# see https://github.com/pytorch/pytorch/issues/2575
-from .contrib import lightgbm, pytorch, statsmodels, tensorflow, xgboost
-from .metrics import pairwise
-
-for _mod in [xgboost, tensorflow, pytorch, lightgbm, proxima, neighbors, statsmodels]:
-    _mod.register_op()
-
-del _mod, pairwise, preprocessing, utils


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

learn.contrib is not required.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #567

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
