### PR TITLE
BUG: Match more error  message

### DIFF
--- a/python/xorbits/_mars/services/cluster/uploader.py
+++ b/python/xorbits/_mars/services/cluster/uploader.py
@@ -91,9 +91,7 @@ class NodeInfoUploaderActor(mo.Actor):
             except asyncio.CancelledError:  # pragma: no cover
                 break
             except RuntimeError as ex:  # pragma: no cover
-                if "cannot schedule new futures after interpreter shutdown" not in str(
-                    ex
-                ):
+                if "cannot schedule new futures" not in str(ex):
                     # when atexit is triggered, the default pool might be shutdown
                     # and to_thread will fail
                     break

--- a/python/xorbits/_mars/services/storage/core.py
+++ b/python/xorbits/_mars/services/storage/core.py
@@ -642,10 +642,7 @@ class StorageManagerActor(mo.StatelessActor):
                 except asyncio.CancelledError:  # pragma: no cover
                     break
                 except RuntimeError as ex:  # pragma: no cover
-                    if (
-                        "cannot schedule new futures after interpreter shutdown"
-                        not in str(ex)
-                    ):
+                    if "cannot schedule new futures" not in str(ex):
                         # when atexit is triggered, the default pool might be shutdown
                         # and to_thread will fail
                         break


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
For some versions of Python, it raises `RuntimeError: cannot schedule new futures after shutdown`, use "cannot schedule new futures " to match error message.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
