### PR TITLE
BUG: Fix RuntimeError: cannot schedule new futures after shutdown

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "requests>=2.4.0",
     "cloudpickle>=2.2.1; python_version>='3.11'",
     "cloudpickle==1.5.0; python_version<'3.11'",
-    "xoscar>=0.0.3",
+    "xoscar>=0.0.8",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    xoscar>=0.0.3
+    xoscar>=0.0.8
     numpy>=1.14.0
     pandas>=1.0.0
     scipy>=1.0.0; sys_platform!="win32" or python_version>="3.10"

--- a/python/xorbits/_mars/services/cluster/uploader.py
+++ b/python/xorbits/_mars/services/cluster/uploader.py
@@ -90,11 +90,6 @@ class NodeInfoUploaderActor(mo.Actor):
                     self._uploaded_future.set_result(None)
             except asyncio.CancelledError:  # pragma: no cover
                 break
-            except RuntimeError as ex:  # pragma: no cover
-                if "cannot schedule new futures" not in str(ex):
-                    # when atexit is triggered, the default pool might be shutdown
-                    # and to_thread will fail
-                    break
             except (
                 Exception
             ) as ex:  # pragma: no cover  # noqa: E722  # nosec  # pylint: disable=bare-except
@@ -166,6 +161,13 @@ class NodeInfoUploaderActor(mo.Actor):
                     self._env_uploaded = True
                 except ValueError:
                     pass
+        except RuntimeError as ex:  # pragma: no cover
+            if "cannot schedule new futures" not in str(ex):
+                # when atexit is triggered, the default pool might be shutdown
+                # and to_thread will fail
+                return
+            logger.exception(f"Failed to upload node info")
+            raise
         except:  # noqa: E722  # nosec  # pylint: disable=bare-except  # pragma: no cover
             logger.exception(f"Failed to upload node info")
             raise


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

This error is raised because the thread pool is shutdown in incorrect order. This PR just suppresses errors.

Similar issue: https://github.com/dask/distributed/issues/6087

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #587 

Fixed minimal version

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
