### PR TITLE
BUG: Fix `pd.read_csv` with encoding parameter

### DIFF
--- a/python/xorbits/_mars/dataframe/datasource/read_csv.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_csv.py
@@ -259,6 +259,7 @@ class DataFrameReadCSV(
                 # The first chunk contains header
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs["header"] = op.header
+                csv_kwargs["dtype"] = dtypes.to_dict()
             if op.usecols:
                 usecols = op.usecols if isinstance(op.usecols, list) else [op.usecols]
             else:
@@ -719,6 +720,7 @@ def read_csv(
             names=names,
             header=header,
             skiprows=skiprows,
+            **kwargs,
         )
         if header == "infer" and names is not None:
             # ignore header as we always specify names

--- a/python/xorbits/_mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/python/xorbits/_mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -711,6 +711,22 @@ def test_read_csv_execution(setup):
         mdf2 = md.read_csv(testdir, index_col=0, chunk_bytes=50).execute().fetch()
         pd.testing.assert_frame_equal(df, mdf2.sort_index())
 
+    with tempfile.TemporaryDirectory() as tempdir:
+        s = "随机生成的中文字符串"
+        file_path = os.path.join(tempdir, "test.csv")
+        df = pd.DataFrame(
+            {"col1": range(len(s)), "col2": np.random.rand(len(s)), "col3": list(s)}
+        )
+        df.to_csv(file_path, encoding="gbk", index=False)
+        pdf = pd.read_csv(file_path, encoding="gbk")
+        r = md.read_csv(file_path, encoding="gbk")
+        mdf = r.execute().fetch()
+        pd.testing.assert_frame_equal(pdf, mdf)
+
+        r = md.read_csv(file_path, encoding="gbk", chunk_bytes=12)
+        mdf = r.execute().fetch()
+        pd.testing.assert_frame_equal(pdf, mdf)
+
 
 csv_with_comment = """# comment line
 1 2.2


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix `pd.read_csv` with encoding parameter.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #613 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
