### PR TITLE
BUG: Fix `_generate_value` when building mock dataframe

### DIFF
--- a/python/xorbits/_mars/dataframe/tests/test_utils.py
+++ b/python/xorbits/_mars/dataframe/tests/test_utils.py
@@ -20,6 +20,7 @@ from typing import Dict, List
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from ...config import option_context
@@ -32,6 +33,8 @@ from ..utils import (
     _get_index_map,
     auto_merge_chunks,
     build_concatenated_rows_frame,
+    build_df,
+    build_empty_df,
     build_split_idx_to_origin_idx,
     decide_dataframe_chunk_sizes,
     decide_series_chunk_size,
@@ -730,3 +733,12 @@ def test_index_map(setup_gpu, gpu):
         actual = _get_index_map(src, func4)
         expected = df.index.map(func4)
         pd.testing.assert_index_equal(actual, expected)
+
+
+def test_build_df():
+    table = pa.table({"a": [1, 2, 3], "b": list("abc")})
+    df = DataFrame(table.to_pandas(types_mapper=pd.ArrowDtype))
+    r1 = build_df(df)
+    pd.testing.assert_series_equal(r1.dtypes, df.dtypes)
+    r2 = build_empty_df(df.dtypes)
+    pd.testing.assert_series_equal(r2.dtypes, df.dtypes)

--- a/python/xorbits/_mars/dataframe/utils.py
+++ b/python/xorbits/_mars/dataframe/utils.py
@@ -609,6 +609,8 @@ def _generate_value(dtype, fill_value):
         np.object_: lambda x: str(fill_value),
     }
     # otherwise, just use dtype.type itself to convert
+    if hasattr(dtype, "numpy_dtype"):
+        dtype = dtype.numpy_dtype
     convert = dispatch.get(dtype.type, dtype.type)
     return convert(fill_value)
 
@@ -627,7 +629,7 @@ def build_empty_df(dtypes, index=None, gpu: Optional[bool] = False):
         # Even if ``s`` is a cudf object, ``s.dtype`` is always a numpy type,
         # so ``pd.api.types.is_dtype_equal`` method is called properly here.
         if not pd.api.types.is_dtype_equal(s.dtype, dtype):
-            df.iloc[:, i] = s.astype(dtype)
+            df.isetitem(i, s.astype(dtype))
 
     df.columns = columns
     return df[:length] if len(df) > length else df


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix `_generate_value` when building mock dataframe.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #637 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
