### PR TITLE
ENH: Compatible with scikit-learn 1.3.0

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -215,8 +215,7 @@ jobs:
             "tiledb-py>=0.4.3,<0.6.0" "tiledb<2.0.0" || true
         fi
         if [[ "$MODULE" == "_mars/learn" ]]; then
-          # remove when compatible with scikit-learn 1.3.0 
-          pip install scikit-learn\<1.3.0
+          pip install scikit-learn
           pip install xgboost lightgbm keras tensorflow faiss-cpu\<1.7.3 torch torchvision \
             statsmodels tsfresh dask[complete] mimesis\<9.0.0
         fi

--- a/python/xorbits/_mars/learn/cluster/_k_means_init.py
+++ b/python/xorbits/_mars/learn/cluster/_k_means_init.py
@@ -26,6 +26,7 @@ from ...tensor.random import RandomStateField
 from ...utils import has_unknown_shape
 from ..metrics import euclidean_distances
 from ..operands import LearnOperand, LearnOperandMixin
+from ..utils.core import sklearn_version
 
 
 def _kmeans_plus_plus_init(
@@ -225,14 +226,23 @@ class KMeansPlusPlusInit(LearnOperand, LearnOperandMixin):
         )
 
         with device(device_id):
-            ctx[op.outputs[0].key] = _kmeans_plusplus(
-                x,
-                op.n_clusters,
-                sample_weight=sample_weight,
-                x_squared_norms=x_squared_norms,
-                random_state=op.state,
-                n_local_trials=op.n_local_trials,
-            )[0]
+            if sklearn_version() >= "1.3.0":
+                ctx[op.outputs[0].key] = _kmeans_plusplus(
+                    x,
+                    op.n_clusters,
+                    sample_weight=sample_weight,
+                    x_squared_norms=x_squared_norms,
+                    random_state=op.state,
+                    n_local_trials=op.n_local_trials,
+                )[0]
+            else:
+                ctx[op.outputs[0].key] = _kmeans_plusplus(
+                    x,
+                    op.n_clusters,
+                    x_squared_norms=x_squared_norms,
+                    random_state=op.state,
+                    n_local_trials=op.n_local_trials,
+                )[0]
 
 
 ###############################################################################

--- a/python/xorbits/_mars/learn/cluster/_k_means_init.py
+++ b/python/xorbits/_mars/learn/cluster/_k_means_init.py
@@ -235,7 +235,7 @@ class KMeansPlusPlusInit(LearnOperand, LearnOperandMixin):
                     random_state=op.state,
                     n_local_trials=op.n_local_trials,
                 )[0]
-            else:
+            else:  # pragma: no cover
                 ctx[op.outputs[0].key] = _kmeans_plusplus(
                     x,
                     op.n_clusters,

--- a/python/xorbits/_mars/learn/cluster/_kmeans.py
+++ b/python/xorbits/_mars/learn/cluster/_kmeans.py
@@ -493,6 +493,7 @@ def _init_centroids(
     X,
     n_clusters=8,
     init="k-means++",
+    sample_weight=None,
     random_state=None,
     x_squared_norms=None,
     init_size=None,
@@ -558,7 +559,11 @@ def _init_centroids(
 
     if isinstance(init, str) and init == "k-means++":
         centers = _k_init(
-            X, n_clusters, random_state=random_state, x_squared_norms=x_squared_norms
+            X,
+            n_clusters,
+            sample_weight=sample_weight,
+            random_state=random_state,
+            x_squared_norms=x_squared_norms,
         )
     elif isinstance(init, str) and init == "k-means||":
         centers = _scalable_k_init(
@@ -879,6 +884,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         self._check_params(X)
         random_state = check_random_state(self.random_state).to_numpy()
+        sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 
         tol = _tolerance(X, self.tol)
 
@@ -914,6 +920,7 @@ class KMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                 X,
                 self.n_clusters,
                 init,
+                sample_weight=sample_weight,
                 random_state=random_state,
                 x_squared_norms=x_squared_norms,
                 oversampling_factor=self.oversampling_factor,

--- a/python/xorbits/_mars/learn/cluster/tests/test_k_means.py
+++ b/python/xorbits/_mars/learn/cluster/tests/test_k_means.py
@@ -23,7 +23,6 @@ import scipy.sparse as sp
 try:
     from sklearn.datasets import make_blobs
     from sklearn.metrics.cluster import v_measure_score
-    from sklearn.utils._testing import assert_raise_message
 except ImportError:
     pass
 
@@ -216,12 +215,10 @@ def _check_fitted_model(km, n_clusters, n_features, true_labels):
     assert km.inertia_ > 0.0
 
     # check error on dataset being too small
-    assert_raise_message(
-        ValueError,
-        "n_samples=1 should be >= n_clusters=%d" % km.n_clusters,
-        km.fit,
-        [[0.0, 1.0]],
-    )
+    with pytest.raises(
+        ValueError, match="n_samples=1 should be >= n_clusters=%d" % km.n_clusters
+    ):
+        km.fit([[0.0, 1.0]])
 
 
 @pytest.mark.skipif(KMeans is None, reason="scikit-learn not installed")

--- a/python/xorbits/_mars/learn/datasets/tests/test_samples_generator.py
+++ b/python/xorbits/_mars/learn/datasets/tests/test_samples_generator.py
@@ -17,12 +17,8 @@ from collections import defaultdict
 from functools import partial
 
 import numpy as np
-from sklearn.utils._testing import (
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_raise_message,
-    assert_raises,
-)
+import pytest
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from .... import tensor as mt
 from ....tensor.linalg import svd
@@ -164,32 +160,24 @@ def test_make_classification_informative_features(setup):
                         err_msg="Clusters are not centered on hypercube vertices",
                     )
                 else:
-                    assert_raises(
-                        AssertionError,
-                        assert_array_almost_equal,
-                        np.abs(centroid) / class_sep,
-                        np.ones(n_informative),
-                        decimal=5,
-                        err_msg="Clusters should not be centered "
-                        "on hypercube vertices",
-                    )
+                    with pytest.raises(AssertionError):
+                        assert_array_almost_equal(
+                            np.abs(centroid) / class_sep,
+                            np.ones(n_informative),
+                            decimal=5,
+                            err_msg="Clusters should not be centered on hypercube vertices",
+                        )
 
-    assert_raises(
-        ValueError,
-        make,
-        n_features=2,
-        n_informative=2,
-        n_classes=5,
-        n_clusters_per_class=1,
-    )
-    assert_raises(
-        ValueError,
-        make,
-        n_features=2,
-        n_informative=2,
-        n_classes=3,
-        n_clusters_per_class=2,
-    )
+    with pytest.raises(ValueError):
+        make(n_features=2, n_informative=2, n_classes=5, n_clusters_per_class=1)
+
+    with pytest.raises(ValueError):
+        make(
+            n_features=2,
+            n_informative=2,
+            n_classes=3,
+            n_clusters_per_class=2,
+        )
 
 
 def test_make_regression(setup):
@@ -297,29 +285,13 @@ def test_make_blobs_error(setup):
     n_samples = [20, 20, 20]
     centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
     cluster_stds = np.array([0.05, 0.2, 0.4])
-    wrong_centers_msg = (
-        "Length of `n_samples` not consistent "
-        f"with number of centers. Got n_samples = {n_samples} "
-        f"and centers = {centers[:-1]}"
-    )
-    assert_raise_message(
-        ValueError, wrong_centers_msg, make_blobs, n_samples, centers=centers[:-1]
-    )
-    wrong_std_msg = (
-        "Length of `clusters_std` not consistent with "
-        f"number of centers. Got centers = {mt.tensor(centers)} "
-        f"and cluster_std = {cluster_stds[:-1]}"
-    )
-    assert_raise_message(
-        ValueError,
-        wrong_std_msg,
-        make_blobs,
-        n_samples,
-        centers=centers,
-        cluster_std=cluster_stds[:-1],
-    )
+    with pytest.raises(ValueError):
+        make_blobs(n_samples, centers=centers[:-1])
+    with pytest.raises(ValueError):
+        make_blobs(n_samples, centers=centers, cluster_std=cluster_stds[:-1])
     wrong_type_msg = f"Parameter `centers` must be array-like. Got {3!r} instead"
-    assert_raise_message(ValueError, wrong_type_msg, make_blobs, n_samples, centers=3)
+    with pytest.raises(ValueError, match=wrong_type_msg):
+        make_blobs(n_samples, centers=3)
 
 
 def test_make_low_rank_matrix(setup):

--- a/python/xorbits/_mars/learn/decomposition/tests/test_pca.py
+++ b/python/xorbits/_mars/learn/decomposition/tests/test_pca.py
@@ -18,14 +18,8 @@ from itertools import product
 import numpy as np
 import pytest
 import scipy as sp
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from sklearn import datasets
-from sklearn.utils._testing import (
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_raise_message,
-    assert_raises,
-    assert_raises_regex,
-)
 
 from .... import tensor as mt
 from .._pca import PCA, _assess_dimension, _infer_dimension
@@ -334,24 +328,22 @@ def test_pca_validation(setup):
                 else:
                     solver_reported = solver
 
-                assert_raises_regex(
+                with pytest.raises(
                     ValueError,
-                    f"n_components={n_components}L? must be between "
+                    match=rf"n_components={n_components}L? must be between "
                     rf"{lower_limit[solver]}L? and min\(n_samples, n_features\)="
-                    f"{smallest_d}L? with svd_solver='{solver_reported}'",
-                    PCA(n_components, svd_solver=solver).fit,
-                    data,
-                )
+                    rf"{smallest_d}L? with svd_solver='{solver_reported}'",
+                ):
+                    PCA(n_components, svd_solver=solver).fit(data)
 
         n_components = 1.0
         type_ncom = type(n_components)
-        assert_raise_message(
+        with pytest.raises(
             ValueError,
-            f"n_components={n_components} must be of type int "
+            match=f"n_components={n_components} must be of type int "
             f"when greater than or equal to 1, was of type={type_ncom}",
-            PCA(n_components, svd_solver=solver).fit,
-            data,
-        )
+        ):
+            PCA(n_components, svd_solver=solver).fit(data)
 
 
 def test_n_components_none(setup):
@@ -436,7 +428,8 @@ def test_n_components_mle(setup):
             error_message = (
                 f"n_components='mle' cannot be a string with svd_solver='{solver}'"
             )
-            assert_raise_message(ValueError, error_message, pca.fit, X)
+            with pytest.raises(ValueError, match=error_message):
+                pca.fit(X)
     assert n_components_dict["auto"] == n_components_dict["full"]
 
 
@@ -661,7 +654,8 @@ def test_pca_sparse_input(setup):
 
         pca = PCA(n_components=3, svd_solver=svd_solver)
 
-        assert_raises(TypeError, pca.fit, X)
+        with pytest.raises(TypeError):
+            pca.fit(X)
 
 
 def test_pca_bad_solver(setup):

--- a/python/xorbits/_mars/learn/decomposition/tests/test_truncated_svd.py
+++ b/python/xorbits/_mars/learn/decomposition/tests/test_truncated_svd.py
@@ -16,8 +16,8 @@
 import numpy as np
 import pytest
 import scipy.sparse as sp
+from numpy.testing import assert_array_almost_equal, assert_array_less
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import assert_array_almost_equal, assert_array_less
 
 from .... import tensor as mt
 from .. import TruncatedSVD

--- a/python/xorbits/_mars/learn/metrics/tests/test_classification.py
+++ b/python/xorbits/_mars/learn/metrics/tests/test_classification.py
@@ -15,16 +15,16 @@
 
 import numpy as np
 import pytest
+from numpy.testing import (
+    assert_almost_equal,
+    assert_array_almost_equal,
+    assert_array_equal,
+)
 from sklearn import datasets, svm
 from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 from sklearn.utils import check_random_state
 from sklearn.utils._mocking import MockDataFrame
-from sklearn.utils._testing import (
-    assert_almost_equal,
-    assert_array_almost_equal,
-    assert_array_equal,
-)
 
 from .... import execute, fetch
 from .... import tensor as mt

--- a/python/xorbits/_mars/learn/metrics/tests/test_ranking.py
+++ b/python/xorbits/_mars/learn/metrics/tests/test_ranking.py
@@ -19,13 +19,13 @@ import warnings
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.metrics import accuracy_score as sklearn_accuracy_score
 from sklearn.metrics import auc as sklearn_auc
 from sklearn.metrics import roc_curve as sklearn_roc_curve
 from sklearn.metrics.tests.test_ranking import _auc, make_prediction
 from sklearn.utils import check_random_state
-from sklearn.utils._testing import assert_almost_equal, assert_array_almost_equal
 
 from .... import dataframe as md
 from .... import tensor as mt

--- a/python/xorbits/_mars/learn/metrics/tests/test_regression.py
+++ b/python/xorbits/_mars/learn/metrics/tests/test_regression.py
@@ -17,12 +17,12 @@ from itertools import product
 
 import numpy as np
 import pytest
-from sklearn.exceptions import UndefinedMetricWarning
-from sklearn.utils._testing import (
+from numpy.testing import (
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
 )
+from sklearn.exceptions import UndefinedMetricWarning
 
 from .... import tensor as mt
 from .. import r2_score

--- a/python/xorbits/_mars/learn/neighbors/base.py
+++ b/python/xorbits/_mars/learn/neighbors/base.py
@@ -24,6 +24,7 @@ from ...tensor.reshape.reshape import _reshape as reshape_unchecked
 from ..metrics import pairwise_distances_topk
 from ..metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from ..utils import check_array
+from ..utils.core import sklearn_version
 from ..utils.validation import check_is_fitted
 from ._ball_tree import SklearnBallTree, ball_tree_query, create_ball_tree
 from ._faiss import METRIC_TO_FAISS_METRIC_TYPE, build_faiss_index, faiss_query
@@ -32,8 +33,12 @@ from ._kneighbors_graph import KNeighborsGraph
 from ._proxima import METRIC_TO_PROXIMA_METRIC_TYPE, build_proxima_index, proxima_query
 
 VALID_METRICS = dict(
-    ball_tree=SklearnBallTree.valid_metrics(),
-    kd_tree=SklearnKDTree.valid_metrics(),
+    ball_tree=SklearnBallTree.valid_metrics()
+    if sklearn_version() >= "1.3.0"
+    else SklearnBallTree.valid_metrics,
+    kd_tree=SklearnKDTree.valid_metrics()
+    if sklearn_version() >= "1.3.0"
+    else SklearnKDTree.valid_metrics,
     # The following list comes from the
     # sklearn.metrics.pairwise doc string
     brute=(

--- a/python/xorbits/_mars/learn/neighbors/base.py
+++ b/python/xorbits/_mars/learn/neighbors/base.py
@@ -32,8 +32,8 @@ from ._kneighbors_graph import KNeighborsGraph
 from ._proxima import METRIC_TO_PROXIMA_METRIC_TYPE, build_proxima_index, proxima_query
 
 VALID_METRICS = dict(
-    ball_tree=SklearnBallTree.valid_metrics,
-    kd_tree=SklearnKDTree.valid_metrics,
+    ball_tree=SklearnBallTree.valid_metrics(),
+    kd_tree=SklearnKDTree.valid_metrics(),
     # The following list comes from the
     # sklearn.metrics.pairwise doc string
     brute=(

--- a/python/xorbits/_mars/learn/preprocessing/tests/test_data.py
+++ b/python/xorbits/_mars/learn/preprocessing/tests/test_data.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import pytest
+from numpy.testing import assert_allclose, assert_array_almost_equal
 from sklearn.datasets import load_iris
 from sklearn.utils import gen_batches
-from sklearn.utils._testing import assert_allclose, assert_array_almost_equal
 
 from .... import tensor as mt
 from .. import MinMaxScaler, minmax_scale

--- a/python/xorbits/_mars/learn/semi_supervised/tests/test_label_propagation.py
+++ b/python/xorbits/_mars/learn/semi_supervised/tests/test_label_propagation.py
@@ -15,10 +15,10 @@
 
 import numpy as np
 import pytest
+from numpy.testing import assert_no_warnings
 from sklearn.datasets import make_classification
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import train_test_split
-from sklearn.utils._testing import assert_no_warnings
 
 from .... import tensor as mt
 from ...metrics.pairwise import rbf_kernel

--- a/python/xorbits/_mars/learn/utils/core.py
+++ b/python/xorbits/_mars/learn/utils/core.py
@@ -154,3 +154,9 @@ def sort_by(
     df = DataFrame(i_to_tensors)
     sorted_df = df.sort_values(by_name, ascending=ascending)
     return [sorted_df[i].to_tensor() for i in range(len(tensors))]
+
+
+def sklearn_version():
+    import sklearn
+
+    return sklearn.__version__

--- a/python/xorbits/_mars/learn/utils/tests/test_multiclass.py
+++ b/python/xorbits/_mars/learn/utils/tests/test_multiclass.py
@@ -18,8 +18,8 @@ from itertools import product
 import numpy as np
 import pytest
 import scipy.sparse as sps
+from numpy.testing import assert_array_equal
 from scipy.sparse import csr_matrix
-from sklearn.utils._testing import assert_array_equal
 from sklearn.utils.estimator_checks import _NotAnArray
 from sklearn.utils.multiclass import is_multilabel as sklearn_is_multilabel
 from sklearn.utils.multiclass import type_of_target as sklearn_type_of_target


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- support scikit-learn 1.3.0
- compatible with previous version of scikit-learn, tested on scikit-learn 1.2.2

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #558 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
