### PR TITLE
FEAT: MMAP storage backend

### DIFF
--- a/python/xorbits/_mars/deploy/oscar/local.py
+++ b/python/xorbits/_mars/deploy/oscar/local.py
@@ -73,6 +73,7 @@ async def new_cluster_in_isolation(
     enable_internal_addr: bool = None,
     oscar_extra_conf: dict = None,
     log_config: dict = None,
+    storage_config: Optional[dict] = None,
 ) -> ClientType:
     cluster = LocalCluster(
         address,
@@ -95,6 +96,7 @@ async def new_cluster_in_isolation(
         enable_internal_addr=enable_internal_addr,
         oscar_extra_conf=oscar_extra_conf,
         log_config=log_config,
+        storage_config=storage_config,
     )
     await cluster.start()
     return await LocalClient.create(cluster, timeout)
@@ -181,6 +183,7 @@ class LocalCluster:
         enable_internal_addr: str = None,
         oscar_extra_conf: dict = None,
         log_config: dict = None,
+        storage_config: Optional[dict] = None,
     ):
         # auto choose the subprocess_start_method.
         if subprocess_start_method is None:
@@ -233,6 +236,11 @@ class LocalCluster:
         # assuming all the memory is available.
         if self._config.get("scheduling", {}).get("mem_hard_limit", None) is None:
             self._config["scheduling"]["mem_hard_limit"] = None
+
+        if storage_config is not None:
+            backend = list(storage_config.keys())[0]
+            self._config["storage"]["backends"] = [backend]
+            self._config["storage"][backend] = storage_config[backend]
 
         self._bands_to_resource = execution_config.get_deploy_band_resources()
         self._supervisor_pool = None

--- a/python/xorbits/_mars/storage/__init__.py
+++ b/python/xorbits/_mars/storage/__init__.py
@@ -16,6 +16,7 @@
 from .base import StorageLevel, get_storage_backend
 from .cuda import CudaStorage
 from .filesystem import FileSystemStorage
+from .mmap import MMAPStorage
 from .shared_memory import SharedMemoryStorage
 
 try:

--- a/python/xorbits/_mars/storage/mmap.py
+++ b/python/xorbits/_mars/storage/mmap.py
@@ -1,0 +1,103 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import mmap
+from typing import Dict, List, Tuple, Union
+
+import cloudpickle
+from xoscar.serialization import deserialize
+from xoscar.serialization.aio import BUFFER_SIZES_NAME, get_header_length
+
+from ..utils import implements
+from .base import ObjectInfo, StorageBackend, StorageLevel, register_storage_backend
+from .core import StorageFileObject
+from .filesystem import DiskStorage
+
+
+@register_storage_backend
+class MMAPStorage(DiskStorage):
+    name = "mmap"
+    is_seekable = True
+
+    def __init__(self, **kw):
+        DiskStorage.__init__(self, **kw)
+
+    @classmethod
+    @implements(StorageBackend.setup)
+    async def setup(cls, **kwargs) -> Tuple[Dict, Dict]:
+        disk_init, disk_teardown = await DiskStorage.setup(**kwargs)
+
+        return disk_init, disk_teardown
+
+    @staticmethod
+    @implements(StorageBackend.teardown)
+    async def teardown(**kwargs):
+        await DiskStorage.teardown(**kwargs)
+
+    @property
+    @implements(StorageBackend.level)
+    def level(self) -> StorageLevel:
+        return StorageLevel.MEMORY
+
+    @property
+    @implements(StorageBackend.size)
+    def size(self) -> Union[int, None]:
+        return self._size
+
+    @staticmethod
+    def _get_file_via_mmap(object_id: str):
+        with open(object_id, "r+b") as f:
+            mm = mmap.mmap(f.fileno(), 0)
+            header_bytes = mm[:11]
+            header_length = get_header_length(header_bytes)
+            header = cloudpickle.loads(mm[11 : 11 + header_length])
+            buffer_sizes = header[0].pop(BUFFER_SIZES_NAME)
+            # get buffers
+            buffers = []
+            start = 11 + header_length
+            for size in buffer_sizes:
+                buffers.append(mm[start : start + size])
+                start = start + size
+            mm.close()
+            return deserialize(header, buffers)
+
+    @implements(StorageBackend.get)
+    async def get(self, object_id, **kwargs) -> object:
+        return await asyncio.to_thread(self._get_file_via_mmap, object_id)
+
+    @implements(StorageBackend.put)
+    async def put(self, obj, importance=0) -> ObjectInfo:
+        return await super().put(obj, importance=importance)
+
+    @implements(StorageBackend.object_info)
+    async def object_info(self, object_id) -> ObjectInfo:
+        return await super().object_info(object_id)
+
+    @implements(StorageBackend.delete)
+    async def delete(self, object_id):
+        await super().delete(object_id)
+
+    @implements(StorageBackend.open_writer)
+    async def open_writer(self, size=None) -> StorageFileObject:
+        return await super().open_writer(size=size)
+
+    @implements(StorageBackend.open_reader)
+    async def open_reader(self, object_id) -> StorageFileObject:
+        with open(object_id, "r+b") as f:
+            mm = mmap.mmap(f.fileno(), 0)
+            return StorageFileObject(mm, object_id)
+
+    @implements(StorageBackend.list)
+    async def list(self) -> List:  # pragma: no cover
+        raise NotImplementedError("MMAP storage does not support list")

--- a/python/xorbits/_mars/storage/mmap.py
+++ b/python/xorbits/_mars/storage/mmap.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import mmap
+import warnings
 from typing import Dict, List, Tuple, Union
 
 import cloudpickle
@@ -43,7 +44,16 @@ class MMAPStorage(DiskStorage):
     @staticmethod
     @implements(StorageBackend.teardown)
     async def teardown(**kwargs):
-        await DiskStorage.teardown(**kwargs)
+        fs = kwargs.get("fs")
+        root_dirs = kwargs.get("root_dirs")
+        try:
+            for d in root_dirs:
+                fs.delete(d, recursive=True)
+        except:  # pragma: no cover
+            warnings.warn(
+                f"Unexpected exceptions occur when deleting directories, "
+                f"please delete these directories manually: {root_dirs}"
+            )
 
     @property
     @implements(StorageBackend.level)

--- a/python/xorbits/deploy/__init__.py
+++ b/python/xorbits/deploy/__init__.py
@@ -31,6 +31,7 @@ def init(
     cuda_devices: Union[List[int], List[List[int]], str] = "auto",
     web: Union[bool, str] = "auto",
     new: bool = True,
+    storage_config: Optional[Dict] = None,
     **kwargs,
 ) -> None:
     """
@@ -96,6 +97,15 @@ def init(
         .. note::
 
           Take effect only when ``init_local`` is False
+
+    storage_config: dict, optional
+        storage backend and its configuration when init a new local cluster.
+        Using ``shared_memory`` storage backend by default.
+        Currently, support `shared_memory`` and ``mmap`` two options.
+
+        .. note::
+
+          Take effect only when ``init_local`` is True
     """
     default_session = session.get_default_session()
     if init_local is True and default_session is not None:
@@ -103,6 +113,16 @@ def init(
             f"`init_local` cannot be True if has initialized,"
             f"call `shutdown` before init."
         )
+    if storage_config is not None:
+        backends = list(storage_config.keys())
+        if len(backends) > 1 or len(backends) == 0:
+            raise ValueError("Only support one storage backend.")
+        backend = backends[0]
+        if backend not in ["shared_memory", "mmap"]:
+            raise ValueError(
+                "Only support one of these storage backends: `shared_memory`, `mmap`."
+            )
+
     if init_local is no_default:
         # if address not specified and has not initialized,
         # force to initialize a local runtime.
@@ -129,6 +149,7 @@ def init(
                 mem_bytes=mem_bytes,
                 cuda_devices=cuda_devices,
                 web=web,
+                storage_config=storage_config,
             )
         )
     kw.update(kwargs)

--- a/python/xorbits/deploy/tests/test_deploy.py
+++ b/python/xorbits/deploy/tests/test_deploy.py
@@ -75,4 +75,5 @@ def test_init_with_storage_config():
     init(storage_config={"mmap": {"root_dirs": tmp_dir}})
     assert repr(pd.Series([1, 2, 3]).sum()) == "6"
     _safe_shutdown()
-    assert not os.path.exists(tmp_dir)
+    if sys.platform != "win32":
+        assert not os.path.exists(tmp_dir)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Use mmap as storage backend.
Now Xorbits can run the complete TPCH SF100 queries on a single  MacOS laptop with 32GB memory.

Future work:
- Use shm as the main storage, and use the mmap as spill storage.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
