### PR TITLE
CHORE: Deprecate ``use_inf_as_na`` option

### DIFF
--- a/python/xorbits/_mars/config.py
+++ b/python/xorbits/_mars/config.py
@@ -343,9 +343,6 @@ default_options.register_option("serialize_method", "pickle")
 
 # dataframe-related options
 default_options.register_option(
-    "dataframe.mode.use_inf_as_na", False, validator=is_bool
-)
-default_options.register_option(
     "dataframe.use_arrow_dtype", None, validator=any_validator(is_null, is_bool)
 )
 default_options.register_option(

--- a/python/xorbits/_mars/dataframe/groupby/aggregation.py
+++ b/python/xorbits/_mars/dataframe/groupby/aggregation.py
@@ -30,7 +30,6 @@ from ...core.custom_log import redirect_custom_log
 from ...core.operand import OperandStage
 from ...serialization.serializables import (
     AnyField,
-    BoolField,
     DictField,
     Int32Field,
     Int64Field,
@@ -170,7 +169,6 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
     groupby_params = DictField("groupby_params")
 
     method = StringField("method")
-    use_inf_as_na = BoolField("use_inf_as_na")
 
     # for chunk
     combine_size = Int32Field("combine_size")
@@ -1286,18 +1284,14 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
     @redirect_custom_log
     @enter_current_session
     def execute(cls, ctx, op: "DataFrameGroupByAgg"):
-        try:
-            pd.set_option("mode.use_inf_as_na", op.use_inf_as_na)
-            if op.stage == OperandStage.map:
-                cls._execute_map(ctx, op)
-            elif op.stage == OperandStage.combine:
-                cls._execute_combine(ctx, op)
-            elif op.stage == OperandStage.agg:
-                cls._execute_agg(ctx, op)
-            else:  # pragma: no cover
-                raise ValueError("Aggregation operand not executable")
-        finally:
-            pd.reset_option("mode.use_inf_as_na")
+        if op.stage == OperandStage.map:
+            cls._execute_map(ctx, op)
+        elif op.stage == OperandStage.combine:
+            cls._execute_combine(ctx, op)
+        elif op.stage == OperandStage.agg:
+            cls._execute_agg(ctx, op)
+        else:  # pragma: no cover
+            raise ValueError("Aggregation operand not executable")
 
 
 def agg(groupby, func=None, method="auto", combine_size=None, *args, **kwargs):
@@ -1355,8 +1349,6 @@ def agg(groupby, func=None, method="auto", combine_size=None, *args, **kwargs):
             func, *args, _call_agg=True, index=index_value, **kwargs
         )
 
-    use_inf_as_na = kwargs.pop("_use_inf_as_na", options.dataframe.mode.use_inf_as_na)
-
     agg_op = DataFrameGroupByAgg(
         raw_func=func,
         raw_func_kw=kwargs,
@@ -1365,6 +1357,5 @@ def agg(groupby, func=None, method="auto", combine_size=None, *args, **kwargs):
         groupby_params=groupby.op.groupby_params,
         combine_size=combine_size or options.combine_size,
         chunk_store_limit=options.chunk_store_limit,
-        use_inf_as_na=use_inf_as_na,
     )
     return agg_op(groupby)

--- a/python/xorbits/_mars/dataframe/missing/tests/test_missing.py
+++ b/python/xorbits/_mars/dataframe/missing/tests/test_missing.py
@@ -226,19 +226,10 @@ def test_replace():
     assert r.chunks[0].op.limit is None
 
 
-@pytest.mark.parametrize("inf_as_na", [True, False])
-def test_isna(setup, inf_as_na):
-    from ....config import options
+def test_isna(setup):
     from ..checkna import isna
 
-    old_mars_inf_as_na = options.dataframe.mode.use_inf_as_na
-    options.dataframe.mode.use_inf_as_na = inf_as_na
-    # this option could be changed by mars execution.
-    old_pd_inf_as_na = pd.get_option("mode.use_inf_as_na")
-    pd.options.mode.use_inf_as_na = inf_as_na
-
     # scalars
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     assert isna("dog") == pd.isna("dog")
     assert isna(None) == pd.isna(None)
     assert isna(md.NA) == pd.isna(pd.NA)
@@ -247,47 +238,39 @@ def test_isna(setup, inf_as_na):
     assert isna(type) == pd.isna(type)
 
     # multi index
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     with pytest.raises(NotImplementedError):
         midx = md.MultiIndex()
         isna(midx)
 
     # list
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     l = [1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT]
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     actual = isna(l).execute().fetch()
     expected = pd.isna(l)
     np.testing.assert_array_equal(expected, actual)
 
     # tuple
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     t = (1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT)
     assert not isna(t)
 
     # numpy ndarray
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     narr = np.array((1, 2, 3, np.Inf, np.NaN))
     actual = isna(narr).execute().fetch()
     expected = pd.isna(narr)
     np.testing.assert_array_equal(expected, actual)
 
     # pandas index
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     pi = pd.Index((1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT))
     actual = isna(pi).execute().fetch()
     expected = pd.isna(pi)
     np.testing.assert_array_equal(expected, actual)
 
     # pandas series
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     ps = pd.Series((1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT))
     actual = isna(ps).execute().fetch()
     expected = pd.isna(ps)
     pd.testing.assert_series_equal(expected, actual)
 
     # pandas dataframe
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     pdf = pd.DataFrame(
         {"foo": (1, 2, 3, np.Inf, pd.NA), "bar": (4, 5, 6, np.NaN, pd.NaT)}
     )
@@ -296,7 +279,6 @@ def test_isna(setup, inf_as_na):
     pd.testing.assert_frame_equal(expected, actual)
 
     # mars tensor
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     marr = mt.tensor(narr)
     actual = isna(marr).execute().fetch()
     expected = pd.isna(narr)
@@ -305,7 +287,6 @@ def test_isna(setup, inf_as_na):
     # mars index
     from ...datasource.index import from_pandas as from_pandas_index
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     mi = from_pandas_index(pi)
     actual = isna(mi).execute().fetch()
     expected = pd.isna(pi)
@@ -314,7 +295,6 @@ def test_isna(setup, inf_as_na):
     # mars series
     from ...datasource.series import from_pandas as from_pandas_series
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     ms = from_pandas_series(ps)
     actual = isna(ms).execute().fetch()
     expected = pd.isna(ps)
@@ -323,29 +303,16 @@ def test_isna(setup, inf_as_na):
     # mars dataframe
     from ...datasource.dataframe import from_pandas as from_pandas_df
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     mdf = from_pandas_df(pdf)
     actual = isna(mdf).execute().fetch()
     expected = pd.isna(pdf)
     pd.testing.assert_frame_equal(expected, actual)
 
-    options.dataframe.mode.use_inf_as_na = old_mars_inf_as_na
-    pd.options.mode.use_inf_as_na = old_pd_inf_as_na
 
-
-@pytest.mark.parametrize("inf_as_na", [True, False])
-def test_notna(setup, inf_as_na):
-    from ....config import options
+def test_notna(setup):
     from ..checkna import notna
 
-    old_mars_inf_as_na = options.dataframe.mode.use_inf_as_na
-    options.dataframe.mode.use_inf_as_na = inf_as_na
-    # this option could be changed by mars execution.
-    old_pd_inf_as_na = pd.get_option("mode.use_inf_as_na")
-    pd.options.mode.use_inf_as_na = inf_as_na
-
     # scalars
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     assert notna("dog") == pd.notna("dog")
     assert notna(None) == pd.notna(None)
     assert notna(md.NA) == pd.notna(pd.NA)
@@ -354,46 +321,39 @@ def test_notna(setup, inf_as_na):
     assert notna(type) == pd.notna(type)
 
     # multi index
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     with pytest.raises(NotImplementedError):
         midx = md.MultiIndex()
         notna(midx)
 
     # list
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     l = [1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT]
     actual = notna(l).execute().fetch()
     expected = pd.notna(l)
     np.testing.assert_array_equal(expected, actual)
 
     # tuple
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     t = (1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT)
     assert notna(t)
 
     # numpy ndarray
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     narr = np.array((1, 2, 3, np.Inf, np.NaN))
     actual = notna(narr).execute().fetch()
     expected = pd.notna(narr)
     np.testing.assert_array_equal(expected, actual)
 
     # pandas index
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     pi = pd.Index((1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT))
     actual = notna(pi).execute().fetch()
     expected = pd.notna(pi)
     np.testing.assert_array_equal(expected, actual)
 
     # pandas series
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     ps = pd.Series((1, 2, 3, np.Inf, np.NaN, pd.NA, pd.NaT))
     actual = notna(ps).execute().fetch()
     expected = pd.notna(ps)
     pd.testing.assert_series_equal(expected, actual)
 
     # pandas dataframe
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     pdf = pd.DataFrame(
         {"foo": (1, 2, 3, np.Inf, pd.NA), "bar": (4, 5, 6, np.NaN, pd.NaT)}
     )
@@ -402,7 +362,6 @@ def test_notna(setup, inf_as_na):
     pd.testing.assert_frame_equal(expected, actual)
 
     # mars tensor
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     marr = mt.tensor(narr)
     actual = notna(marr).execute().fetch()
     expected = pd.notna(narr)
@@ -411,7 +370,6 @@ def test_notna(setup, inf_as_na):
     # mars index
     from ...datasource.index import from_pandas as from_pandas_index
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     mi = from_pandas_index(pi)
     actual = notna(mi).execute().fetch()
     expected = pd.notna(pi)
@@ -420,7 +378,6 @@ def test_notna(setup, inf_as_na):
     # mars series
     from ...datasource.series import from_pandas as from_pandas_series
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     ms = from_pandas_series(ps)
     actual = notna(ms).execute().fetch()
     expected = pd.notna(ps)
@@ -429,11 +386,7 @@ def test_notna(setup, inf_as_na):
     # mars dataframe
     from ...datasource.dataframe import from_pandas as from_pandas_df
 
-    assert pd.get_option("mode.use_inf_as_na") == inf_as_na
     mdf = from_pandas_df(pdf)
     actual = notna(mdf).execute().fetch()
     expected = pd.notna(pdf)
     pd.testing.assert_frame_equal(expected, actual)
-
-    options.dataframe.mode.use_inf_as_na = old_mars_inf_as_na
-    pd.options.mode.use_inf_as_na = old_pd_inf_as_na

--- a/python/xorbits/_mars/dataframe/reduction/all.py
+++ b/python/xorbits/_mars/dataframe/reduction/all.py
@@ -17,7 +17,6 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import (
     DATAFRAME_TYPE,
@@ -86,7 +85,6 @@ def all_series(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameAll(
         axis=axis,
         skipna=skipna,
@@ -94,7 +92,6 @@ def all_series(
         bool_only=bool_only,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(series)
@@ -109,7 +106,6 @@ def all_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     output_types = [OutputType.series] if axis is not None else [OutputType.scalar]
     op = DataFrameAll(
         axis=axis,
@@ -118,13 +114,11 @@ def all_dataframe(
         bool_only=bool_only,
         combine_size=combine_size,
         output_types=output_types,
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
 
 
 def all_index(idx):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameAll(output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
+    op = DataFrameAll(output_types=[OutputType.scalar])
     return op(idx)

--- a/python/xorbits/_mars/dataframe/reduction/any.py
+++ b/python/xorbits/_mars/dataframe/reduction/any.py
@@ -17,7 +17,6 @@ import numpy as np
 import pandas as pd
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import (
     DATAFRAME_TYPE,
@@ -86,7 +85,6 @@ def any_series(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameAny(
         axis=axis,
         skipna=skipna,
@@ -94,7 +92,6 @@ def any_series(
         bool_only=bool_only,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(series)
@@ -109,7 +106,6 @@ def any_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     output_types = [OutputType.series] if axis is not None else [OutputType.scalar]
     op = DataFrameAny(
         axis=axis,
@@ -118,13 +114,11 @@ def any_dataframe(
         bool_only=bool_only,
         combine_size=combine_size,
         output_types=output_types,
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
 
 
 def any_index(index):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
-    op = DataFrameAny(output_types=[OutputType.scalar], use_inf_as_na=use_inf_as_na)
+    op = DataFrameAny(output_types=[OutputType.scalar])
     return op(index)

--- a/python/xorbits/_mars/dataframe/reduction/count.py
+++ b/python/xorbits/_mars/dataframe/reduction/count.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
 
@@ -40,13 +39,11 @@ class DataFrameCount(DataFrameReductionOperand, DataFrameReductionMixin):
 
 
 def count_series(series, level=None, combine_size=None, **kw):
-    use_inf_as_na = kw.pop("_use_inf_as_na", options.dataframe.mode.use_inf_as_na)
     method = kw.pop("method", None)
     op = DataFrameCount(
         level=level,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(series)
@@ -55,7 +52,6 @@ def count_series(series, level=None, combine_size=None, **kw):
 def count_dataframe(
     df, axis=0, level=None, numeric_only=False, combine_size=None, **kw
 ):
-    use_inf_as_na = kw.pop("_use_inf_as_na", options.dataframe.mode.use_inf_as_na)
     method = kw.pop("method", None)
     op = DataFrameCount(
         axis=axis,
@@ -63,7 +59,6 @@ def count_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/cummax.py
+++ b/python/xorbits/_mars/dataframe/reduction/cummax.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from .core import DataFrameCumReductionMixin, DataFrameCumReductionOperand
 
 
@@ -24,11 +23,9 @@ class DataFrameCummax(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 
 def cummax(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameCummax(
         axis=axis,
         skipna=skipna,
         output_types=df.op.output_types,
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/cummin.py
+++ b/python/xorbits/_mars/dataframe/reduction/cummin.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from .core import DataFrameCumReductionMixin, DataFrameCumReductionOperand
 
 
@@ -24,11 +23,9 @@ class DataFrameCummin(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 
 def cummin(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameCummin(
         axis=axis,
         skipna=skipna,
         output_types=df.op.output_types,
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/cumprod.py
+++ b/python/xorbits/_mars/dataframe/reduction/cumprod.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from .core import DataFrameCumReductionMixin, DataFrameCumReductionOperand
 
 
@@ -24,11 +23,9 @@ class DataFrameCumprod(DataFrameCumReductionOperand, DataFrameCumReductionMixin)
 
 
 def cumprod(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameCumprod(
         axis=axis,
         skipna=skipna,
         output_types=df.op.output_types,
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/cumsum.py
+++ b/python/xorbits/_mars/dataframe/reduction/cumsum.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from .core import DataFrameCumReductionMixin, DataFrameCumReductionOperand
 
 
@@ -24,11 +23,9 @@ class DataFrameCumsum(DataFrameCumReductionOperand, DataFrameCumReductionMixin):
 
 
 def cumsum(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameCumsum(
         axis=axis,
         skipna=skipna,
         output_types=df.op.output_types,
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/custom_reduction.py
+++ b/python/xorbits/_mars/dataframe/reduction/custom_reduction.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from ...serialization.serializables import AnyField
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -35,12 +34,10 @@ class DataFrameCustomReduction(DataFrameReductionOperand, DataFrameReductionMixi
 
 
 def build_custom_reduction_result(df, custom_reduction_obj, method=None):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     output_type = OutputType.series if df.ndim == 2 else OutputType.scalar
     op = DataFrameCustomReduction(
         custom_reduction=custom_reduction_obj,
         output_types=[output_type],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/kurtosis.py
+++ b/python/xorbits/_mars/dataframe/reduction/kurtosis.py
@@ -16,7 +16,6 @@
 import numpy as np
 
 from ... import opcodes
-from ...config import options
 from ...core import ENTITY_TYPE, OutputType
 from ...serialization.serializables import BoolField
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -83,7 +82,6 @@ def kurt_series(
     fisher=True,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameKurtosis(
         axis=axis,
         skipna=skipna,
@@ -92,7 +90,6 @@ def kurt_series(
         bias=bias,
         fisher=fisher,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -109,7 +106,6 @@ def kurt_dataframe(
     fisher=True,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameKurtosis(
         axis=axis,
         skipna=skipna,
@@ -119,7 +115,6 @@ def kurt_dataframe(
         fisher=fisher,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/max.py
+++ b/python/xorbits/_mars/dataframe/reduction/max.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
 
@@ -29,14 +28,12 @@ class DataFrameMax(DataFrameReductionOperand, DataFrameReductionMixin):
 
 
 def max_series(df, axis=None, skipna=True, level=None, combine_size=None, method=None):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMax(
         axis=axis,
         skipna=skipna,
         level=level,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -51,7 +48,6 @@ def max_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMax(
         axis=axis,
         skipna=skipna,
@@ -59,18 +55,15 @@ def max_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
 
 
 def max_index(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMax(
         axis=axis,
         skipna=skipna,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/mean.py
+++ b/python/xorbits/_mars/dataframe/reduction/mean.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
 
@@ -34,14 +33,12 @@ class DataFrameMean(DataFrameReductionOperand, DataFrameReductionMixin):
 
 
 def mean_series(df, axis=None, skipna=True, level=None, combine_size=None, method=None):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMean(
         axis=axis,
         skipna=skipna,
         level=level,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -56,7 +53,6 @@ def mean_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMean(
         axis=axis,
         skipna=skipna,
@@ -64,7 +60,6 @@ def mean_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/min.py
+++ b/python/xorbits/_mars/dataframe/reduction/min.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
 
@@ -29,14 +28,12 @@ class DataFrameMin(DataFrameReductionOperand, DataFrameReductionMixin):
 
 
 def min_series(df, axis=None, skipna=True, level=None, combine_size=None, method=None):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMin(
         axis=axis,
         skipna=skipna,
         level=level,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -51,7 +48,6 @@ def min_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMin(
         axis=axis,
         skipna=skipna,
@@ -59,18 +55,15 @@ def min_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
 
 
 def min_index(df, axis=None, skipna=True):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameMin(
         axis=axis,
         skipna=skipna,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/prod.py
+++ b/python/xorbits/_mars/dataframe/reduction/prod.py
@@ -16,7 +16,6 @@
 import numpy as np
 
 from ... import opcodes
-from ...config import options
 from ...core import OutputType
 from .aggregation import where_function
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -48,7 +47,6 @@ class DataFrameProd(DataFrameReductionOperand, DataFrameReductionMixin):
 def prod_series(
     df, axis=None, skipna=True, level=None, min_count=0, combine_size=None, method=None
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameProd(
         axis=axis,
         skipna=skipna,
@@ -56,7 +54,6 @@ def prod_series(
         min_count=min_count,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -72,7 +69,6 @@ def prod_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameProd(
         axis=axis,
         skipna=skipna,
@@ -81,7 +77,6 @@ def prod_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/sem.py
+++ b/python/xorbits/_mars/dataframe/reduction/sem.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from ...serialization.serializables import Int32Field
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -48,7 +47,6 @@ class DataFrameSem(DataFrameReductionOperand, DataFrameReductionMixin):
 def sem_series(
     series, axis=None, skipna=True, level=None, ddof=1, combine_size=None, method=None
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSem(
         axis=axis,
         skipna=skipna,
@@ -56,7 +54,6 @@ def sem_series(
         ddof=ddof,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(series)
@@ -72,7 +69,6 @@ def sem_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSem(
         axis=axis,
         skipna=skipna,
@@ -81,7 +77,6 @@ def sem_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/skew.py
+++ b/python/xorbits/_mars/dataframe/reduction/skew.py
@@ -16,7 +16,6 @@
 import numpy as np
 
 from ... import opcodes
-from ...config import options
 from ...core import ENTITY_TYPE, OutputType
 from ...serialization.serializables import BoolField
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -68,7 +67,6 @@ class DataFrameSkew(DataFrameReductionOperand, DataFrameReductionMixin):
 def skew_series(
     df, axis=None, skipna=True, level=None, combine_size=None, bias=False, method=None
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSkew(
         axis=axis,
         skipna=skipna,
@@ -76,7 +74,6 @@ def skew_series(
         combine_size=combine_size,
         bias=bias,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -92,7 +89,6 @@ def skew_dataframe(
     bias=False,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSkew(
         axis=axis,
         skipna=skipna,
@@ -101,7 +97,6 @@ def skew_dataframe(
         bias=bias,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/sum.py
+++ b/python/xorbits/_mars/dataframe/reduction/sum.py
@@ -16,7 +16,6 @@
 import numpy as np
 
 from ... import opcodes
-from ...config import options
 from ...core import OutputType
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
 
@@ -49,7 +48,6 @@ class DataFrameSum(DataFrameReductionOperand, DataFrameReductionMixin):
 def sum_series(
     df, axis=None, skipna=True, level=None, min_count=0, combine_size=None, method=None
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSum(
         axis=axis,
         skipna=skipna,
@@ -57,7 +55,6 @@ def sum_series(
         min_count=min_count,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)
@@ -73,7 +70,6 @@ def sum_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameSum(
         axis=axis,
         skipna=skipna,
@@ -82,7 +78,6 @@ def sum_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)

--- a/python/xorbits/_mars/dataframe/reduction/var.py
+++ b/python/xorbits/_mars/dataframe/reduction/var.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from ... import opcodes as OperandDef
-from ...config import options
 from ...core import OutputType
 from ...serialization.serializables import Int32Field
 from .core import DataFrameReductionMixin, DataFrameReductionOperand
@@ -51,7 +50,6 @@ class DataFrameVar(DataFrameReductionOperand, DataFrameReductionMixin):
 def var_series(
     series, axis=None, skipna=True, level=None, ddof=1, combine_size=None, method=None
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameVar(
         axis=axis,
         skipna=skipna,
@@ -59,7 +57,6 @@ def var_series(
         ddof=ddof,
         combine_size=combine_size,
         output_types=[OutputType.scalar],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(series)
@@ -75,7 +72,6 @@ def var_dataframe(
     combine_size=None,
     method=None,
 ):
-    use_inf_as_na = options.dataframe.mode.use_inf_as_na
     op = DataFrameVar(
         axis=axis,
         skipna=skipna,
@@ -84,7 +80,6 @@ def var_dataframe(
         numeric_only=numeric_only,
         combine_size=combine_size,
         output_types=[OutputType.series],
-        use_inf_as_na=use_inf_as_na,
         method=method,
     )
     return op(df)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Since pandas 2.1.0, ``mode.use_inf_as_na`` has been deprecated. https://github.com/pandas-dev/pandas/issues/51684

- Deprecate `use_inf_as_na` option

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
