### PR TITLE
FEAT: Add `xorbits.sklearn` module

### DIFF
--- a/python/xorbits/__init__.py
+++ b/python/xorbits/__init__.py
@@ -24,6 +24,7 @@ def _install():
     from .lightgbm import _install as _install_lightgbm
     from .numpy import _install as _install_numpy
     from .pandas import _install as _install_pandas
+    from .sklearn import _install as _install_sklearn
     from .web import _install as _install_web
     from .xgboost import _install as _install_xgboost
 
@@ -34,6 +35,7 @@ def _install():
     _install_xgboost()
     _install_datasets()
     _install_experimental()
+    _install_sklearn()
 
 
 _install()

--- a/python/xorbits/sklearn/__init__.py
+++ b/python/xorbits/sklearn/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+__all__ = [
+    "cluster",
+    "datasets",
+    "decomposition",
+    "ensemble",
+    "linear_model",
+    "metrics",
+    "model_selection",
+    "neighbors",
+    "preprocessing",
+    "semi_supervised",
+]

--- a/python/xorbits/sklearn/cluster/__init__.py
+++ b/python/xorbits/sklearn/cluster/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_CLUSTER_CALLABLES
+
+    return list(MARS_SKLEARN_CLUSTER_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.cluster as sk_cluster
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_CLUSTER_CALLABLES
+
+    if name in MARS_SKLEARN_CLUSTER_CALLABLES:
+        return MARS_SKLEARN_CLUSTER_CALLABLES[name]
+    else:
+        if not hasattr(sk_cluster, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_cluster, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/cluster/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/cluster/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_CLUSTER_CALLABLES

--- a/python/xorbits/sklearn/cluster/mars_adapters/core.py
+++ b/python/xorbits/sklearn/cluster/mars_adapters/core.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.cluster as sk_cluster
+
+from ...._mars.learn import cluster as mars_cluster
+from ...._mars.learn.cluster import KMeans as MarsKMeans
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class KMeans(SKLearnBase):
+    _marscls = MarsKMeans
+
+
+SKLEARN_CLUSTER_CLS_MAP = {KMeans: MarsKMeans}
+
+MARS_SKLEARN_CLUSTER_CALLABLES = _collect_module_callables(
+    mars_cluster, sk_cluster, skip_members=["register_op"]
+)
+_install_cls_members(
+    SKLEARN_CLUSTER_CLS_MAP, MARS_SKLEARN_CLUSTER_CALLABLES, sk_cluster
+)
+attach_module_callable_docstring(KMeans, sk_cluster, sk_cluster.KMeans)

--- a/python/xorbits/sklearn/cluster/tests/__init__.py
+++ b/python/xorbits/sklearn/cluster/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/cluster/tests/test_core.py
+++ b/python/xorbits/sklearn/cluster/tests/test_core.py
@@ -1,0 +1,57 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+
+from .... import numpy as xnp
+from .. import KMeans
+
+n_rows = 1000
+n_clusters = 8
+n_columns = 10
+chunk_size = 200
+rs = xnp.random.RandomState(0)
+X = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
+X_new = rs.rand(n_rows, n_columns, chunk_size=chunk_size)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = KMeans.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.cluster."
+    )
+
+    docstring = KMeans.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.cluster._kmeans.KMeans."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="sci-kit-learn not installed")
+def test_kmeans_cluster():
+    kms = KMeans(n_clusters=n_clusters, random_state=0)
+    kms.fit(X)
+    predict = kms.predict(X_new).fetch()
+
+    assert kms.n_clusters == n_clusters
+    assert np.shape(kms.labels_.fetch()) == (n_rows,)
+    assert np.shape(kms.cluster_centers_.fetch()) == (n_clusters, n_columns)
+    assert np.shape(predict) == (n_rows,)

--- a/python/xorbits/sklearn/datasets/__init__.py
+++ b/python/xorbits/sklearn/datasets/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_DATASETS_CALLABLES
+
+    return list(MARS_SKLEARN_DATASETS_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.datasets as sk_datasets
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_DATASETS_CALLABLES
+
+    if name in MARS_SKLEARN_DATASETS_CALLABLES:
+        return MARS_SKLEARN_DATASETS_CALLABLES[name]
+    else:
+        if not hasattr(sk_datasets, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_datasets, name)):
+                raise NotImplementedError(f"This function is not implemented yet.")
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/datasets/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/datasets/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_DATASETS_CALLABLES

--- a/python/xorbits/sklearn/datasets/mars_adapters/core.py
+++ b/python/xorbits/sklearn/datasets/mars_adapters/core.py
@@ -1,0 +1,22 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.datasets as sk_datasets
+
+from ...._mars.learn import datasets as mars_datasets
+from ...utils import _collect_module_callables
+
+MARS_SKLEARN_DATASETS_CALLABLES = _collect_module_callables(
+    mars_datasets, sk_datasets, skip_members=["register_op"]
+)

--- a/python/xorbits/sklearn/datasets/tests/__init__.py
+++ b/python/xorbits/sklearn/datasets/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/datasets/tests/test_core.py
+++ b/python/xorbits/sklearn/datasets/tests/test_core.py
@@ -1,0 +1,131 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import pytest
+
+import xorbits.numpy as np
+
+from ... import datasets
+from ...datasets import (
+    make_blobs,
+    make_classification,
+    make_low_rank_matrix,
+    make_regression,
+)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = datasets.make_blobs.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.datasets."
+    )
+
+    docstring = datasets.make_classification.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.datasets."
+    )
+
+    docstring = datasets.make_low_rank_matrix.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.datasets."
+    )
+
+    docstring = datasets.make_regression.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.datasets."
+    )
+
+
+def test_make_classification():
+    weights = [0.1, 0.25]
+    X, y = make_classification(
+        n_samples=100,
+        n_features=20,
+        n_informative=5,
+        n_redundant=1,
+        n_repeated=1,
+        n_classes=3,
+        n_clusters_per_class=1,
+        hypercube=False,
+        shift=None,
+        scale=None,
+        weights=weights,
+        random_state=0,
+        flip_y=-1,
+    )
+    X, y = X.execute().fetch(), y.execute().fetch()
+    assert X.shape == (100, 20)
+    assert y.shape == (100,)
+    assert np.unique(y).shape == (3,)
+    assert (y == 0).sum() == 10
+    assert (y == 1).sum() == 25
+    assert (y == 2).sum() == 65
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_make_regression():
+    X, y, c = make_regression(
+        n_samples=100,
+        n_features=10,
+        n_informative=3,
+        effective_rank=5,
+        coef=True,
+        bias=0.0,
+        noise=1.0,
+        random_state=0,
+    )
+    X, y, c = X.execute().fetch(), y.execute().fetch(), c.execute().fetch()
+    assert X.shape == (100, 10), "X shape mismatch"
+    assert y.shape == (100,), "y shape mismatch"
+    assert c.shape == (10,), "coef shape mismatch"
+    assert sum(c != 0.0) == 3, "Unexpected number of informative features"
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_make_blobs():
+    cluster_stds = np.array([0.05, 0.2, 0.4])
+    cluster_centers = np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    X, y = make_blobs(
+        random_state=0,
+        n_samples=50,
+        n_features=2,
+        centers=cluster_centers,
+        cluster_std=cluster_stds,
+    )
+    X, y = X.execute().fetch(), y.execute().fetch()
+    assert X.shape == (50, 2)
+    assert y.shape == (50,)
+    assert np.unique(y).shape == (3,)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_make_low_rank_matrix():
+    X = make_low_rank_matrix(
+        n_samples=50,
+        n_features=25,
+        effective_rank=5,
+        tail_strength=0.01,
+        random_state=0,
+    )
+    X = X.execute().fetch()
+    assert X.shape == (50, 25)
+    _, s, _ = np.linalg.svd(X)
+    s = s.execute().fetch()
+    assert (s.sum() - 5) < 0.1

--- a/python/xorbits/sklearn/decomposition/__init__.py
+++ b/python/xorbits/sklearn/decomposition/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_DECOMP_CALLABLES
+
+    return list(MARS_SKLEARN_DECOMP_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.decomposition as sk_decomp
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_DECOMP_CALLABLES
+
+    if name in MARS_SKLEARN_DECOMP_CALLABLES:
+        return MARS_SKLEARN_DECOMP_CALLABLES[name]
+    else:
+        if not hasattr(sk_decomp, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_decomp, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/decomposition/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/decomposition/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_DECOMP_CALLABLES

--- a/python/xorbits/sklearn/decomposition/mars_adapters/core.py
+++ b/python/xorbits/sklearn/decomposition/mars_adapters/core.py
@@ -1,0 +1,43 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.decomposition as sk_decomposition
+
+from ...._mars.learn import decomposition as mars_decomposition
+from ...._mars.learn.decomposition import PCA as MarsPCA
+from ...._mars.learn.decomposition import TruncatedSVD as MarsTruncatedSVD
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class PCA(SKLearnBase):
+    _marscls = MarsPCA
+
+
+class TruncatedSVD(SKLearnBase):
+    _marscls = MarsTruncatedSVD
+
+
+SKLEARN_DECOMP_CLS_MAP = {PCA: MarsPCA, TruncatedSVD: MarsTruncatedSVD}
+
+MARS_SKLEARN_DECOMP_CALLABLES = _collect_module_callables(
+    mars_decomposition, sk_decomposition, skip_members=["register_op"]
+)
+_install_cls_members(
+    SKLEARN_DECOMP_CLS_MAP, MARS_SKLEARN_DECOMP_CALLABLES, sk_decomposition
+)
+attach_module_callable_docstring(PCA, sk_decomposition, sk_decomposition.PCA)
+attach_module_callable_docstring(
+    TruncatedSVD, sk_decomposition, sk_decomposition.TruncatedSVD
+)

--- a/python/xorbits/sklearn/decomposition/tests/__init__.py
+++ b/python/xorbits/sklearn/decomposition/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/decomposition/tests/test_core.py
+++ b/python/xorbits/sklearn/decomposition/tests/test_core.py
@@ -1,0 +1,87 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from numpy.testing import assert_array_almost_equal, assert_equal
+from sklearn import datasets
+from sklearn.utils import check_random_state
+
+from .. import PCA, TruncatedSVD
+
+iris = np.asarray(datasets.load_iris().data)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = PCA.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.decomposition."
+    )
+
+    docstring = PCA.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.decomposition._pca.PCA."
+    )
+
+    docstring = TruncatedSVD.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.decomposition."
+    )
+
+    docstring = TruncatedSVD.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.decomposition._truncated_svd.TruncatedSVD."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_pca():
+    X = iris
+
+    for n_comp in np.arange(X.shape[1]):
+        pca = PCA(n_components=n_comp, svd_solver="full")
+        pca.fit(X)
+        X_r = pca.transform(X).fetch()
+        assert_equal(X_r.shape[1], n_comp)
+
+        X_r2 = pca.fit_transform(X).fetch()
+        assert_array_almost_equal(X_r, X_r2)
+
+        X_r = pca.transform(X).fetch()
+        X_r2 = pca.fit_transform(X).fetch()
+        assert_array_almost_equal(X_r, X_r2)
+
+        # Test get_covariance and get_precision
+        cov = pca.get_covariance()
+        precision = pca.get_precision()
+        assert_array_almost_equal(np.dot(cov, precision), np.eye(X.shape[1]), 12)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_truncated_svd():
+    shape = 60, 55
+    n_samples, n_features = shape
+    rng = check_random_state(42)
+    X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
+    X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
+    for n_components in (10, 25, 41):
+        tsvd = TruncatedSVD(n_components).fit(X)
+        assert tsvd.n_components == n_components
+        assert tsvd.components_.shape == (n_components, n_features)

--- a/python/xorbits/sklearn/ensemble/__init__.py
+++ b/python/xorbits/sklearn/ensemble/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_EN_CALLABLES
+
+    return list(MARS_SKLEARN_EN_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.ensemble as sk_en
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_EN_CALLABLES
+
+    if name in MARS_SKLEARN_EN_CALLABLES:
+        return MARS_SKLEARN_EN_CALLABLES[name]
+    else:
+        if not hasattr(sk_en, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_en, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/ensemble/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/ensemble/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_EN_CALLABLES

--- a/python/xorbits/sklearn/ensemble/mars_adapters/core.py
+++ b/python/xorbits/sklearn/ensemble/mars_adapters/core.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.ensemble as sk_en
+
+from ...._mars.learn import ensemble as mars_en
+from ...._mars.learn.ensemble import BaggingClassifier as MarsBaggingClassifier
+from ...._mars.learn.ensemble import BaggingRegressor as MarsBaggingRegressor
+from ...._mars.learn.ensemble import IsolationForest as MarsIsolationForest
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class BaggingClassifier(SKLearnBase):
+    _marscls = MarsBaggingClassifier
+
+
+class BaggingRegressor(SKLearnBase):
+    _marscls = MarsBaggingRegressor
+
+
+class IsolationForest(SKLearnBase):
+    _marscls = MarsIsolationForest
+
+
+SKLEARN_EN_CLS_MAP = {
+    BaggingClassifier: MarsBaggingClassifier,
+    IsolationForest: MarsIsolationForest,
+    BaggingRegressor: MarsBaggingRegressor,
+}
+
+MARS_SKLEARN_EN_CALLABLES = _collect_module_callables(
+    mars_en, sk_en, skip_members=["register_op"]
+)
+_install_cls_members(SKLEARN_EN_CLS_MAP, MARS_SKLEARN_EN_CALLABLES, sk_en)
+attach_module_callable_docstring(BaggingClassifier, sk_en, sk_en.BaggingClassifier)
+attach_module_callable_docstring(BaggingRegressor, sk_en, sk_en.BaggingRegressor)
+attach_module_callable_docstring(IsolationForest, sk_en, sk_en.IsolationForest)

--- a/python/xorbits/sklearn/ensemble/tests/__init__.py
+++ b/python/xorbits/sklearn/ensemble/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/ensemble/tests/test_core.py
+++ b/python/xorbits/sklearn/ensemble/tests/test_core.py
@@ -1,0 +1,124 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+from sklearn.svm import SVC
+
+from ...datasets import make_classification, make_regression
+from ...ensemble import BaggingClassifier, BaggingRegressor, IsolationForest
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = BaggingClassifier.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble."
+    )
+
+    docstring = BaggingRegressor.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble."
+    )
+
+    docstring = IsolationForest.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble."
+    )
+
+    docstring = BaggingClassifier.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble._bagging.BaggingClassifier."
+    )
+
+    docstring = BaggingRegressor.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble._bagging.BaggingRegressor."
+    )
+
+    docstring = IsolationForest.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.ensemble._iforest.IsolationForest."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_baggingclassifier():
+    rs = np.random.RandomState(0)
+
+    raw_x, raw_y = make_classification(
+        n_samples=100,
+        n_features=4,
+        n_informative=2,
+        n_redundant=0,
+        random_state=rs,
+        shuffle=False,
+    )
+
+    clf = BaggingClassifier(
+        base_estimator=SVC(),
+        n_estimators=10,
+        max_samples=10,
+        max_features=1,
+        random_state=rs,
+        warm_start=True,
+    )
+
+    clf.fit(raw_x, raw_y)
+    log_proba = clf.predict_log_proba(raw_x)
+    log_proba = log_proba.fetch()
+    exp_log_proba_array = np.exp(log_proba)
+    assert clf.n_estimators == 10
+    assert np.all((exp_log_proba_array >= 0) & (exp_log_proba_array <= 1))
+    assert np.allclose(np.sum(exp_log_proba_array, axis=1), 1.0)
+
+
+def test_bagging_regression():
+    rs = np.random.RandomState(0)
+
+    raw_x, raw_y = make_regression(
+        n_samples=100, n_features=4, n_informative=2, random_state=rs, shuffle=False
+    )
+    clf = BaggingRegressor(
+        base_estimator=LinearRegression(),
+        n_estimators=10,
+        max_samples=10,
+        max_features=0.5,
+        random_state=rs,
+        warm_start=True,
+    )
+    clf.fit(raw_x, raw_y)
+
+    predict_y = clf.predict(raw_x)
+    predict_y_array = predict_y.fetch()
+    assert predict_y_array.shape == raw_y.shape
+
+
+def test_iforest():
+    rs = np.random.RandomState(0)
+    raw_train = rs.poisson(size=(100, 10))
+    raw_test = rs.poisson(size=(200, 10))
+
+    clf = IsolationForest(random_state=rs, n_estimators=10, max_samples=1)
+    pred = clf.fit(raw_train).predict(raw_test).fetch()
+    score = clf.score_samples(raw_test).fetch()
+
+    assert clf.n_estimators == 10
+    assert pred.shape == (200,)
+    assert score.shape == (200,)

--- a/python/xorbits/sklearn/linear_model/__init__.py
+++ b/python/xorbits/sklearn/linear_model/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_LM_CALLABLES
+
+    return list(MARS_SKLEARN_LM_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.linear_model as sk_lm
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_LM_CALLABLES
+
+    if name in MARS_SKLEARN_LM_CALLABLES:
+        return MARS_SKLEARN_LM_CALLABLES[name]
+    else:
+        if not hasattr(sk_lm, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_lm, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/linear_model/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/linear_model/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_LM_CALLABLES

--- a/python/xorbits/sklearn/linear_model/mars_adapters/core.py
+++ b/python/xorbits/sklearn/linear_model/mars_adapters/core.py
@@ -1,0 +1,42 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.linear_model as sk_lm
+
+from ...._mars.learn import linear_model as mars_lm
+from ...._mars.learn.glm import LogisticRegression as MarsLogisticRegression
+from ...._mars.learn.linear_model import LinearRegression as MarsLinearRegression
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class LinearRegression(SKLearnBase):
+    _marscls = MarsLinearRegression
+
+
+class LogisticRegression(SKLearnBase):
+    _marscls = MarsLogisticRegression
+
+
+SKLEARN_LM_CLS_MAP = {
+    LinearRegression: MarsLinearRegression,
+    LogisticRegression: MarsLogisticRegression,
+}
+
+MARS_SKLEARN_LM_CALLABLES = _collect_module_callables(
+    mars_lm, sk_lm, skip_members=["register_op"]
+)
+_install_cls_members(SKLEARN_LM_CLS_MAP, MARS_SKLEARN_LM_CALLABLES, sk_lm)
+attach_module_callable_docstring(LinearRegression, sk_lm, sk_lm.LinearRegression)
+attach_module_callable_docstring(LogisticRegression, sk_lm, sk_lm.LogisticRegression)

--- a/python/xorbits/sklearn/linear_model/tests/__init__.py
+++ b/python/xorbits/sklearn/linear_model/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/linear_model/tests/test_core.py
+++ b/python/xorbits/sklearn/linear_model/tests/test_core.py
@@ -1,0 +1,73 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+
+from .. import LinearRegression, LogisticRegression
+
+n_rows = 100
+n_columns = 5
+X = np.random.rand(n_rows, n_columns)
+y = np.random.rand(n_rows)
+y_cat = np.random.randint(0, 2, n_rows)
+X_new = np.random.rand(n_rows, n_columns)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = LogisticRegression.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.linear_model."
+    )
+
+    docstring = LogisticRegression.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.linear_model._logistic.LogisticRegression."
+    )
+
+    docstring = LinearRegression.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.linear_model."
+    )
+
+    docstring = LinearRegression.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.linear_model._base.LinearRegression."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_linear_regression():
+    lr = LinearRegression()
+    lr.fit(X, y)
+    predict = lr.predict(X_new)
+
+    assert np.shape(lr.coef_.fetch()) == (n_columns,)
+    assert np.shape(lr.intercept_.fetch()) == ()
+    assert np.shape(predict) == (n_rows,)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_logistic_regression():
+    lr = LogisticRegression(max_iter=1)
+    lr.fit(X, y_cat)
+    predict = lr.predict(X_new).fetch()
+
+    assert np.shape(predict) == (n_rows,)

--- a/python/xorbits/sklearn/metrics/__init__.py
+++ b/python/xorbits/sklearn/metrics/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_METRICS_CALLABLES
+
+    return list(MARS_SKLEARN_METRICS_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.metrics as sk_metrics
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_METRICS_CALLABLES
+
+    if name in MARS_SKLEARN_METRICS_CALLABLES:
+        return MARS_SKLEARN_METRICS_CALLABLES[name]
+    else:
+        if not hasattr(sk_metrics, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_metrics, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/metrics/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/metrics/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_METRICS_CALLABLES

--- a/python/xorbits/sklearn/metrics/mars_adapters/core.py
+++ b/python/xorbits/sklearn/metrics/mars_adapters/core.py
@@ -1,0 +1,22 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.metrics as sk_metrics
+
+from ...._mars.learn import metrics as mars_metrics
+from ...utils import _collect_module_callables
+
+MARS_SKLEARN_METRICS_CALLABLES = _collect_module_callables(
+    mars_metrics, sk_metrics, skip_members=["register_op"]
+)

--- a/python/xorbits/sklearn/metrics/tests/__init__.py
+++ b/python/xorbits/sklearn/metrics/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/metrics/tests/test_core.py
+++ b/python/xorbits/sklearn/metrics/tests/test_core.py
@@ -1,0 +1,142 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import inspect
+
+import numpy as np
+import pytest
+
+from ... import metrics
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    for name, f in inspect.getmembers(metrics, inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        docstring = f.__doc__
+        assert docstring is not None
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_classification():
+    from sklearn.metrics import f1_score as sklearn_f1_score
+    from sklearn.metrics import fbeta_score as sklearn_fbeta_score
+    from sklearn.metrics import (
+        multilabel_confusion_matrix as sklearn_multilabel_confusion_matrix,
+    )
+    from sklearn.metrics import (
+        precision_recall_fscore_support as sklearn_precision_recall_fscore_support,
+    )
+    from sklearn.metrics import precision_score as sklearn_precision_score
+    from sklearn.metrics import recall_score as sklearn_recall_score
+
+    from ...metrics import (
+        f1_score,
+        fbeta_score,
+        multilabel_confusion_matrix,
+        precision_recall_fscore_support,
+        precision_score,
+        recall_score,
+    )
+
+    y_true = np.array([0, 1, 2, 0, 1, 2], dtype=np.int64)
+    y_pred = np.array([0, 2, 1, 0, 0, 1], dtype=np.int64)
+
+    np.testing.assert_array_almost_equal(
+        f1_score(y_true, y_pred, average="macro").execute().fetch(),
+        sklearn_f1_score(y_true, y_pred, average="macro"),
+    )
+    np.testing.assert_array_almost_equal(
+        fbeta_score(y_true, y_pred, beta=0.5, average="macro").execute().fetch(),
+        sklearn_fbeta_score(y_true, y_pred, beta=0.5, average="macro"),
+    )
+
+    np.testing.assert_array_almost_equal(
+        precision_score(y_true, y_pred, average="macro").execute().fetch(),
+        sklearn_precision_score(y_true, y_pred, average="macro"),
+    )
+
+    np.testing.assert_array_almost_equal(
+        recall_score(y_true, y_pred, average="macro").execute().fetch(),
+        sklearn_recall_score(y_true, y_pred, average="macro"),
+    )
+
+    np.testing.assert_array_almost_equal(
+        multilabel_confusion_matrix(y_true, y_pred).execute().fetch(),
+        sklearn_multilabel_confusion_matrix(y_true, y_pred),
+    )
+
+    np.testing.assert_array_almost_equal(
+        precision_recall_fscore_support(y_true, y_pred)[0].execute().fetch(),
+        sklearn_precision_recall_fscore_support(y_true, y_pred)[0],
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_scorer():
+    from sklearn.metrics import r2_score
+
+    from ...metrics import get_scorer
+
+    assert get_scorer("r2") is not None
+    assert get_scorer(r2_score) is not None
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_r2_score():
+    from ...metrics import r2_score
+
+    y_true = np.array([[1, 0, 0, 1], [0, 1, 1, 1], [1, 1, 0, 1]])
+    y_pred = np.array([[0, 0, 0, 1], [1, 0, 1, 1], [0, 0, 0, 1]])
+
+    error = r2_score(y_true, y_pred, multioutput="variance_weighted")
+    np.testing.assert_almost_equal(error.fetch(), 1.0 - 5.0 / 2)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_ranking():
+    from sklearn.metrics import accuracy_score as sklearn_accuracy_score
+    from sklearn.metrics import auc as sklearn_auc
+    from sklearn.metrics import roc_curve as sklearn_roc_curve
+    from sklearn.metrics.tests.test_ranking import make_prediction
+
+    from ...metrics import accuracy_score, auc, roc_auc_score, roc_curve
+
+    y_true, y_score, _ = make_prediction(binary=True)
+
+    np.testing.assert_almost_equal(
+        accuracy_score(y_true, y_score).fetch(),
+        sklearn_accuracy_score(y_true, y_score),
+    )
+    rs = np.random.RandomState(0)
+    y = rs.randint(0, 10, (10,))
+    pred = rs.rand(10)
+    fpr, tpr, thresholds = roc_curve(y, pred, pos_label=2)
+    m = auc(fpr, tpr)
+
+    sk_fpr, sk_tpr, sk_threshod = sklearn_roc_curve(
+        y,
+        pred,
+        pos_label=2,
+    )
+    expect_m = sklearn_auc(sk_fpr, sk_tpr)
+    assert pytest.approx(m.fetch()) == expect_m
+    y_true = np.array([0, 0, 1, 1], dtype=np.int64)
+    assert roc_auc_score(y_true, y_true, max_fpr=1) == 1

--- a/python/xorbits/sklearn/model_selection/__init__.py
+++ b/python/xorbits/sklearn/model_selection/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_ML_CALLABLES
+
+    return list(MARS_SKLEARN_ML_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.model_selection as sk_ml
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_ML_CALLABLES
+
+    if name in MARS_SKLEARN_ML_CALLABLES:
+        return MARS_SKLEARN_ML_CALLABLES[name]
+    else:
+        if not hasattr(sk_ml, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_ml, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/model_selection/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/model_selection/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_ML_CALLABLES

--- a/python/xorbits/sklearn/model_selection/mars_adapters/core.py
+++ b/python/xorbits/sklearn/model_selection/mars_adapters/core.py
@@ -1,0 +1,51 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.model_selection as sk_ml
+
+from ...._mars.learn import model_selection as mars_ml
+from ...._mars.learn.model_selection import KFold as MarsKFold
+from ...._mars.learn.model_selection import ParameterGrid as MarsParameterGrid
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class KFold(SKLearnBase):
+    _marscls = MarsKFold
+
+
+class ParameterGrid(SKLearnBase):
+    _marscls = MarsParameterGrid
+
+    def __len__(self):
+        return len(self.mars_instance)
+
+    def __iter__(self):
+        return iter(self.mars_instance)
+
+    def __getitem__(self, index):
+        return self.mars_instance[index]
+
+
+SKLEARN_ML_CLS_MAP = {
+    KFold: MarsKFold,
+    ParameterGrid: MarsParameterGrid,
+}
+
+MARS_SKLEARN_ML_CALLABLES = _collect_module_callables(
+    mars_ml, sk_ml, skip_members=["register_op"]
+)
+_install_cls_members(SKLEARN_ML_CLS_MAP, MARS_SKLEARN_ML_CALLABLES, sk_ml)
+attach_module_callable_docstring(KFold, sk_ml, sk_ml.KFold)
+attach_module_callable_docstring(ParameterGrid, sk_ml, sk_ml.ParameterGrid)

--- a/python/xorbits/sklearn/model_selection/tests/__init__.py
+++ b/python/xorbits/sklearn/model_selection/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/model_selection/tests/test_core.py
+++ b/python/xorbits/sklearn/model_selection/tests/test_core.py
@@ -1,0 +1,66 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+from typing import Iterable, Sized
+
+import numpy as np
+import pytest
+
+from ...model_selection import KFold, ParameterGrid, train_test_split
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = KFold.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.model_selection."
+    )
+
+    docstring = ParameterGrid.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.model_selection."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_parameter_grid():
+    arr1 = [1, 2, 3]
+    params1 = {"foo": arr1}
+    grid1 = ParameterGrid(params1)
+    assert isinstance(grid1, Iterable)
+    assert isinstance(grid1, Sized)
+    assert len(grid1) == 3
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_kfold():
+    X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
+    kf = KFold(n_splits=2)
+    splits = kf.get_n_splits(X)
+    assert splits == 2
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_train_test_split():
+    X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
+    y = np.array([1, 2, 3, 4])
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33)
+    assert X_train.shape == (2, 2)
+    assert X_test.shape == (2, 2)
+    assert y_train.shape == (2,)
+    assert y_test.shape == (2,)

--- a/python/xorbits/sklearn/neighbors/__init__.py
+++ b/python/xorbits/sklearn/neighbors/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_NEIGHBORS_CALLABLES
+
+    return list(MARS_SKLEARN_NEIGHBORS_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.neighbors as sk_neigh
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_NEIGHBORS_CALLABLES
+
+    if name in MARS_SKLEARN_NEIGHBORS_CALLABLES:
+        return MARS_SKLEARN_NEIGHBORS_CALLABLES[name]
+    else:
+        if not hasattr(sk_neigh, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_neigh, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/neighbors/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/neighbors/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_NEIGHBORS_CALLABLES

--- a/python/xorbits/sklearn/neighbors/mars_adapters/core.py
+++ b/python/xorbits/sklearn/neighbors/mars_adapters/core.py
@@ -1,0 +1,39 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.neighbors as sk_neighbors
+
+from ...._mars.learn import neighbors as mars_neighbors
+from ...._mars.learn.neighbors import NearestNeighbors as MarsNearestNeighbors
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class NearestNeighbors(SKLearnBase):
+    _marscls = MarsNearestNeighbors
+
+
+SKLEARN_NEIGHBORS_CLS_MAP = {
+    NearestNeighbors: MarsNearestNeighbors,
+}
+
+MARS_SKLEARN_NEIGHBORS_CALLABLES = _collect_module_callables(
+    mars_neighbors, sk_neighbors, skip_members=["register_op"]
+)
+_install_cls_members(
+    SKLEARN_NEIGHBORS_CLS_MAP, MARS_SKLEARN_NEIGHBORS_CALLABLES, sk_neighbors
+)
+attach_module_callable_docstring(
+    NearestNeighbors, sk_neighbors, sk_neighbors.NearestNeighbors
+)

--- a/python/xorbits/sklearn/neighbors/tests/__init__.py
+++ b/python/xorbits/sklearn/neighbors/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/neighbors/tests/test_core.py
+++ b/python/xorbits/sklearn/neighbors/tests/test_core.py
@@ -1,0 +1,34 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import pytest
+
+from ...neighbors import NearestNeighbors
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = NearestNeighbors.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.neighbors."
+    )
+
+    docstring = NearestNeighbors.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.neighbors._unsupervised.NearestNeighbors."
+    )

--- a/python/xorbits/sklearn/preprocessing/__init__.py
+++ b/python/xorbits/sklearn/preprocessing/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_PREPROC_CALLABLES
+
+    return list(MARS_SKLEARN_PREPROC_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.preprocessing as sk_preproc
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_PREPROC_CALLABLES
+
+    if name in MARS_SKLEARN_PREPROC_CALLABLES:
+        return MARS_SKLEARN_PREPROC_CALLABLES[name]
+    else:
+        if not hasattr(sk_preproc, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_preproc, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/preprocessing/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/preprocessing/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_PREPROC_CALLABLES

--- a/python/xorbits/sklearn/preprocessing/mars_adapters/core.py
+++ b/python/xorbits/sklearn/preprocessing/mars_adapters/core.py
@@ -1,0 +1,51 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.preprocessing as sk_preproc
+
+from ...._mars.learn import preprocessing as mars_preproc
+from ...._mars.learn.preprocessing import LabelBinarizer as MarsLabelBinarizer
+from ...._mars.learn.preprocessing import LabelEncoder as MarsLabelEncoder
+from ...._mars.learn.preprocessing import MinMaxScaler as MarsMinMaxScaler
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class MinMaxScaler(SKLearnBase):
+    _marscls = MarsMinMaxScaler
+
+
+class LabelBinarizer(SKLearnBase):
+    _marscls = MarsLabelBinarizer
+
+
+class LabelEncoder(SKLearnBase):
+    _marscls = MarsLabelEncoder
+
+
+SKLEARN_PREPROC_CLS_MAP = {
+    MinMaxScaler: MarsMinMaxScaler,
+    LabelEncoder: MarsLabelEncoder,
+    LabelBinarizer: MarsLabelBinarizer,
+}
+
+MARS_SKLEARN_PREPROC_CALLABLES = _collect_module_callables(
+    mars_preproc, sk_preproc, skip_members=["register_op"]
+)
+_install_cls_members(
+    SKLEARN_PREPROC_CLS_MAP, MARS_SKLEARN_PREPROC_CALLABLES, sk_preproc
+)
+attach_module_callable_docstring(MinMaxScaler, sk_preproc, sk_preproc.MinMaxScaler)
+attach_module_callable_docstring(LabelBinarizer, sk_preproc, sk_preproc.LabelBinarizer)
+attach_module_callable_docstring(LabelEncoder, sk_preproc, sk_preproc.LabelEncoder)

--- a/python/xorbits/sklearn/preprocessing/tests/__init__.py
+++ b/python/xorbits/sklearn/preprocessing/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/preprocessing/tests/test_core.py
+++ b/python/xorbits/sklearn/preprocessing/tests/test_core.py
@@ -1,0 +1,82 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+
+from ...preprocessing import LabelBinarizer, LabelEncoder, MinMaxScaler
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = MinMaxScaler.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing."
+    )
+
+    docstring = LabelBinarizer.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing."
+    )
+
+    docstring = LabelEncoder.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing."
+    )
+
+    docstring = MinMaxScaler.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing._data.MinMaxScaler."
+    )
+
+    docstring = LabelBinarizer.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing._label.LabelBinarizer."
+    )
+
+    docstring = LabelEncoder.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.preprocessing._label.LabelEncoder."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_min_max_scaler():
+    X = np.array([[1, 2], [2, 4], [4, 8], [8, 16]], dtype=np.float64)
+    scaler = MinMaxScaler()
+    scaler.fit(X)
+    np.testing.assert_array_equal(scaler.data_min_, [1.0, 2.0])
+    np.testing.assert_array_equal(scaler.data_max_, [8.0, 16.0])
+    np.testing.assert_array_equal(scaler.data_range_, [7.0, 14.0])
+
+    X_transformed = scaler.transform(X).fetch()
+    assert X_transformed.shape == (4, 2)
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_label_binarizer():
+    lb = LabelBinarizer()
+    lb.fit([1, 2, 6, 4, 2])
+    assert lb.classes_.tolist() == [1, 2, 4, 6]
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_label_encoder():
+    le = LabelEncoder()
+    le.fit([1, 2, 2, 6])
+    assert le.classes_.tolist() == [1, 2, 6]

--- a/python/xorbits/sklearn/semi_supervised/__init__.py
+++ b/python/xorbits/sklearn/semi_supervised/__init__.py
@@ -1,0 +1,49 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ...core.utils.fallback import unimplemented_func
+
+
+def _install():
+    """Nothing required for installing sklearn."""
+
+
+def __dir__():  # pragma: no cover
+    try:
+        import sklearn
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_SS_CALLABLES
+
+    return list(MARS_SKLEARN_SS_CALLABLES.keys())
+
+
+def __getattr__(name: str):  # pragma: no cover
+    import inspect
+
+    try:
+        import sklearn.semi_supervised as sk_ss
+    except ImportError:
+        raise AttributeError("sklearn is required but not installed.")
+    from .mars_adapters import MARS_SKLEARN_SS_CALLABLES
+
+    if name in MARS_SKLEARN_SS_CALLABLES:
+        return MARS_SKLEARN_SS_CALLABLES[name]
+    else:
+        if not hasattr(sk_ss, name):
+            raise AttributeError(name)
+        else:
+            if inspect.ismethod(getattr(sk_ss, name)):
+                return unimplemented_func()
+            else:
+                raise AttributeError

--- a/python/xorbits/sklearn/semi_supervised/mars_adapters/__init__.py
+++ b/python/xorbits/sklearn/semi_supervised/mars_adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import MARS_SKLEARN_SS_CALLABLES

--- a/python/xorbits/sklearn/semi_supervised/mars_adapters/core.py
+++ b/python/xorbits/sklearn/semi_supervised/mars_adapters/core.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sklearn.semi_supervised as sk_ss
+
+from ...._mars.learn import semi_supervised as mars_ss
+from ...._mars.learn.semi_supervised import LabelPropagation as MarsLabelPropagation
+from ....core.utils.docstring import attach_module_callable_docstring
+from ...utils import SKLearnBase, _collect_module_callables, _install_cls_members
+
+
+class LabelPropagation(SKLearnBase):
+    _marscls = MarsLabelPropagation
+
+
+SKLEARN_SS_CLS_MAP = {
+    LabelPropagation: MarsLabelPropagation,
+}
+
+MARS_SKLEARN_SS_CALLABLES = _collect_module_callables(
+    mars_ss, sk_ss, skip_members=["register_op"]
+)
+_install_cls_members(SKLEARN_SS_CLS_MAP, MARS_SKLEARN_SS_CALLABLES, sk_ss)
+attach_module_callable_docstring(LabelPropagation, sk_ss, sk_ss.LabelPropagation)

--- a/python/xorbits/sklearn/semi_supervised/tests/__init__.py
+++ b/python/xorbits/sklearn/semi_supervised/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/xorbits/sklearn/semi_supervised/tests/test_core.py
+++ b/python/xorbits/sklearn/semi_supervised/tests/test_core.py
@@ -1,0 +1,48 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import sklearn
+except ImportError:  # pragma: no cover
+    sklearn = None
+
+import numpy as np
+import pytest
+
+from ...semi_supervised import LabelPropagation
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_doc():
+    docstring = LabelPropagation.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.semi_supervised."
+    )
+
+    docstring = LabelPropagation.fit.__doc__
+    assert docstring is not None and docstring.endswith(
+        "This docstring was copied from sklearn.semi_supervised._label_propagation.LabelPropagation."
+    )
+
+
+@pytest.mark.skipif(sklearn is None, reason="scikit-learn not installed")
+def test_label_propagation():
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 5)
+    y = np.array([0, 0, 0, 1, 1, -1, -1, -1, -1, -1])
+    lp = LabelPropagation()
+    lp.fit(X, y)
+    assert lp.classes_.tolist() == [0, 1]
+    assert lp.transduction_.tolist() == [0, 0, 0, 1, 1, 0, 0, 0, 0, 0]
+    assert lp.predict(X).tolist() == [0, 0, 0, 1, 1, 0, 0, 0, 0, 0]
+    assert lp.score(X, y) == 0.5

--- a/python/xorbits/sklearn/utils.py
+++ b/python/xorbits/sklearn/utils.py
@@ -1,0 +1,72 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import inspect
+from typing import Callable, Dict, List, Optional
+
+from ..core.adapter import to_mars, wrap_mars_callable
+
+
+class SKLearnBase:
+    def __init__(self, *args, **kwargs):
+        self.mars_instance = self._marscls(*to_mars(args), **to_mars(kwargs))
+
+    def __getattr__(self, name):
+        return getattr(self.mars_instance, name)
+
+
+def wrap_cls_func(marscls: Callable, name: str, submodule):
+    @functools.wraps(getattr(marscls, name))
+    def wrapped(self, *args, **kwargs):
+        return getattr(self.mars_instance, name)(*args, **kwargs)
+
+    return wrap_mars_callable(
+        wrapped,
+        member_name=name,
+        attach_docstring=True,
+        is_cls_member=True,
+        docstring_src_module=submodule,
+        docstring_src_cls=getattr(submodule, marscls.__name__, None),
+    )
+
+
+def _collect_module_callables(
+    mars_module,
+    orig_module,
+    skip_members: Optional[List[str]] = None,
+) -> Dict[str, Callable]:
+    module_callables: Dict[str, Callable] = dict()
+
+    for name, func in inspect.getmembers(mars_module, inspect.isfunction):
+        if skip_members is not None and name in skip_members:
+            continue
+        module_callables[name] = wrap_mars_callable(
+            func,
+            attach_docstring=True,
+            is_cls_member=False,
+            docstring_src_module=orig_module,
+            docstring_src=getattr(orig_module, name, None),
+        )
+    return module_callables
+
+
+def _install_cls_members(
+    module_cls_map, module_callables: Dict[str, Callable], orig_submodule
+):
+    for x_cls, mars_cls in module_cls_map.items():
+        module_callables[x_cls.__name__] = x_cls
+        for name, _ in inspect.getmembers(mars_cls, inspect.isfunction):
+            if not name.startswith("_"):
+                setattr(x_cls, name, wrap_cls_func(mars_cls, name, orig_submodule))


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

This PR aims to export `xorbits._mars.learn` to `xorbits.sklearn`

##  Sub-packages has been added ...

- [x] cluster
- [x] datasets
- [x] decomposition
- [x] ensemble
- [x] linear_model
- [x] metrics
- [x] model_selection
- [x] neighbors
- [x] preprocessing
- [x] semi_supervised

