### PR TITLE
BUG: fix font overflow in `tileabledetail.js`

### DIFF
--- a/python/xorbits/web/ui/src/task_info/TileableDetail.js
+++ b/python/xorbits/web/ui/src/task_info/TileableDetail.js
@@ -57,7 +57,7 @@ class TileableDetail extends React.Component {
           <Tab label="Subtask Info" />
         </Tabs>
         <br />
-        <div>
+        <div style={{ overflow : 'auto' }}>
           {this.state.displayedTileableDetail === 0 ? (
             <React.Fragment>
               <Table size="small" style={{ height: '100%' }}>


### PR DESCRIPTION
## What do these changes do?

The purpose of this PR is to add the `style={{ overflow: 'auto' }}` to the `TileableDetail` component. This addition ensures that when content overflows, the table will display scrollbars, thus improving the user experience.
## Related issue number


Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
