### PR TITLE
BUG: `merge` performance issue caused by `DataFrameAutoMergeMixin`

### DIFF
--- a/python/xorbits/_mars/dataframe/base/cartesian_chunk.py
+++ b/python/xorbits/_mars/dataframe/base/cartesian_chunk.py
@@ -139,9 +139,10 @@ class DataFrameCartesianChunk(DataFrameOperand, DataFrameAutoMergeMixin):
         auto_merge_threshold = op.auto_merge_threshold
         auto_merge_before, auto_merge_after = cls._get_auto_merge_options(op.auto_merge)
 
-        yield from cls._merge_before(
+        merge_before_res = yield from cls._merge_before(
             op, auto_merge_before, auto_merge_threshold, left, right, logger
         )
+        left, right = merge_before_res[0], merge_before_res[1]
 
         if left.ndim == 2 and left.chunk_shape[1] > 1:
             if has_unknown_shape(left):

--- a/python/xorbits/_mars/dataframe/base/core.py
+++ b/python/xorbits/_mars/dataframe/base/core.py
@@ -128,6 +128,7 @@ class DataFrameAutoMergeMixin(DataFrameOperandMixin):
                 right.shape,
                 len(right.chunks),
             )
+        return [left, right]
 
     @classmethod
     def _merge_after(

--- a/python/xorbits/_mars/dataframe/merge/merge.py
+++ b/python/xorbits/_mars/dataframe/merge/merge.py
@@ -744,9 +744,10 @@ class DataFrameMerge(DataFrameOperand, DataFrameAutoMergeMixin):
         auto_merge_threshold = op.auto_merge_threshold
         auto_merge_before, auto_merge_after = cls._get_auto_merge_options(op.auto_merge)
 
-        yield from cls._merge_before(
+        merge_before_res = yield from cls._merge_before(
             op, auto_merge_before, auto_merge_threshold, left, right, logger
         )
+        left, right = merge_before_res[0], merge_before_res[1]
 
         method = cls._choose_merge_method(op, left, right)
         if cls._if_apply_bloom_filter(method, op, left, right):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

Fix a performance issue caused by `DataFrameAutoMergeMixin`.
Without this PR, TPCH sf1 will have the following error:
```
AssertionError
 51%|███████████████████████████████████████████████████▍                                                 |  50.88/100 [00:01<00:00, 50.65it/s]2023-10-13 16:13:55,293 xorbits._mars.services.task.execution.mars.stage 88633 ERROR    Subtask 1bmsxjlcmLYPTmtAN6LlM4X0 errored
Traceback (most recent call last):
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/subtask/worker/processor.py", line 212, in _execute_operand
    return execute(ctx, op)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/core/operand/core.py", line 492, in execute
    result = executor(results, op)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 349, in execute
    ctx[chunk.key] = _base_concat(chunk, inputs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 252, in _base_concat
    return _auto_concat_dataframe_chunks(chunk, inputs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 281, in _auto_concat_dataframe_chunks
    assert n_rows * n_cols == len(inputs)
AssertionError
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 100.00/100 [00:01<00:00, 96.81it/s]
Traceback (most recent call last):
  File "/Users/lichengjie/Projects/workspace/xorbits/benchmarks/tpch/run_queries.py", line 1149, in <module>
    main()
  File "/Users/lichengjie/Projects/workspace/xorbits/benchmarks/tpch/run_queries.py", line 1136, in main
    run_queries(
  File "/Users/lichengjie/Projects/workspace/xorbits/benchmarks/tpch/run_queries.py", line 1053, in run_queries
    globals()[f"q{query:02}"](*queries_to_args[query])
  File "/Users/lichengjie/Projects/workspace/xorbits/benchmarks/tpch/run_queries.py", line 146, in wrapped
    q(*args, **kwargs)
  File "/Users/lichengjie/Projects/workspace/xorbits/benchmarks/tpch/run_queries.py", line 586, in q09
    print(total)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/utils.py", line 38, in inn
    return f(self, *args, **kwargs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/core/data.py", line 299, in __str__
    run(self)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/core/execution.py", line 55, in run
    mars_execute(mars_tileables, **kwargs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/deploy/oscar/session.py", line 1789, in execute
    return session.execute(
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/deploy/oscar/session.py", line 1600, in execute
    execution_info: ExecutionInfo = fut.result(
  File "/Users/lichengjie/miniconda3/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/Users/lichengjie/miniconda3/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/deploy/oscar/session.py", line 1769, in _execute
    await execution_info
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/deploy/oscar/session.py", line 124, in wait
    return await self._aio_task
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/deploy/oscar/session.py", line 884, in _run_in_background
    raise task_result.error.with_traceback(task_result.traceback)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/task/supervisor/processor.py", line 388, in run
    await self._process_stage_chunk_graph(*stage_args)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/task/supervisor/processor.py", line 265, in _process_stage_chunk_graph
    chunk_to_result = await self._executor.execute_subtask_graph(
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/task/execution/mars/executor.py", line 203, in execute_subtask_graph
    return await stage_processor.run()
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/task/execution/mars/stage.py", line 233, in run
    return await self._run()
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/task/execution/mars/stage.py", line 253, in _run
    raise self.result.error.with_traceback(self.result.traceback)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/services/subtask/worker/processor.py", line 212, in _execute_operand
    return execute(ctx, op)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/core/operand/core.py", line 492, in execute
    result = executor(results, op)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 349, in execute
    ctx[chunk.key] = _base_concat(chunk, inputs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 252, in _base_concat
    return _auto_concat_dataframe_chunks(chunk, inputs)
  File "/Users/lichengjie/Projects/workspace/xorbits/python/xorbits/_mars/dataframe/merge/concat.py", line 281, in _auto_concat_dataframe_chunks
    assert n_rows * n_cols == len(inputs)
AssertionError
```
and on TPCH sf1000 merge op would hang and have performance issue.

<!-- Please give a short brief about these changes. -->

## Related issue number
Related PR #699 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
