### PR TITLE
CHORE: Fix `PerformanceWarning` in `pivot` combine stage

### DIFF
--- a/python/xorbits/_mars/dataframe/base/pivot.py
+++ b/python/xorbits/_mars/dataframe/base/pivot.py
@@ -67,11 +67,14 @@ class DataFramePivot(MapReduceOperand, DataFrameOperandMixin):
         input_data = ctx[op.inputs[0].key]
         out = op.outputs[0]
 
-        for dtype in op.output_columns:
-            if dtype not in input_data.dtypes.index:
-                input_data[dtype] = np.nan
+        dtypes = [
+            dtype for dtype in op.output_columns if dtype not in input_data.dtypes.index
+        ]
+        nan_data = pd.DataFrame(
+            {col: [np.nan] for col in dtypes}, index=input_data.index
+        )
 
-        ctx[out.key] = input_data
+        ctx[out.key] = pd.concat([input_data, nan_data], axis=1)
 
     @classmethod
     def execute(cls, ctx: Union[dict, Context], op: "DataFramePivot"):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Fix this warning in `pivot` op combine stage.
```
performancewarning: dataframe is highly fragmented. this is usually the result of calling `frame.insert` many times, which has poor performance. consider joining all columns at once using pd.concat(axis=1) instead. to get a de-fragmented frame, use `newframe = frame.copy()`
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
