### PR TITLE
ENH: Modify `JAX` fusion optimization

### DIFF
--- a/python/xorbits/_mars/optimization/physical/jax.py
+++ b/python/xorbits/_mars/optimization/physical/jax.py
@@ -18,10 +18,11 @@ from typing import List, Tuple, Union
 from ...core import ChunkType
 from ...tensor.fuse import TensorJAXFuseChunk
 from ...tensor.fuse.jax import (
-    ARITHMETIC_SUPPORT,
+    BINARY_ARITHMETIC_SUPPORT,
     JAX_INSTALLED,
     REDUCTION_SUPPORT,
     TREE_SUPPORT,
+    UNARY_ARITHMETIC_SUPPORT,
 )
 from .core import REDUCTION, GraphTraversalOptimizer, _Fuse, register_optimizer
 
@@ -40,7 +41,11 @@ class JAXRuntimeOptimizer(GraphTraversalOptimizer):
                 return REDUCTION
             else:  # pragma: no cover
                 return False
-        if op_type not in ARITHMETIC_SUPPORT and op_type not in TREE_SUPPORT:
+        if (
+            op_type not in UNARY_ARITHMETIC_SUPPORT
+            and op_type not in BINARY_ARITHMETIC_SUPPORT
+            and op_type not in TREE_SUPPORT
+        ):
             return False
         return True
 

--- a/python/xorbits/_mars/tensor/fuse/jax.py
+++ b/python/xorbits/_mars/tensor/fuse/jax.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools as ft
+
 import numpy as np
 
 try:
     import jax
+    import jax.numpy as jnp
     from jax import config
 
     config.update("jax_enable_x64", True)
@@ -34,61 +37,79 @@ class TensorJAXFuseChunk(TensorFuse, TensorFuseChunkMixin):
     @classmethod
     def execute(cls, ctx, op):
         chunk = op.outputs[0]
-        inputs = [ctx[c.key] for c in op.inputs]
+        inputs = [jnp.asarray(ctx[c.key]) for c in op.inputs]
         input_dict = {c.key: i for c, i in zip(op.inputs, inputs)}
-        res = np.array(_evaluate(chunk, input_dict))
+        res = np.asarray(_eval(input_dict, chunk))
         res = _maybe_keepdims(chunk, res)
         if chunk.ndim == 0 and res.ndim == 1 and res.size == 0:
             res = res.dtype.type(0)
         ctx[chunk.key] = res
 
 
-# recursively compute the inputs
-def _evaluate(chunk, input_dict):
-    op_type = type(chunk.op)
+if JAX_INSTALLED:
 
-    if chunk.key in input_dict:
-        return input_dict[chunk.key]
-    elif op_type is TensorJAXFuseChunk:
-        return _evaluate(chunk.composed[-1], input_dict)
-    elif op_type in ARITHMETIC_SUPPORT:
-        if hasattr(chunk.op, "inputs"):
-            if hasattr(chunk.op, "input"):
-                return _get_jax_function(chunk.op)(
-                    _evaluate(chunk.op.input, input_dict)
-                )
-            elif np.isscalar(chunk.op.lhs):
-                rhs = _evaluate(chunk.op.rhs, input_dict)
-                return _get_jax_function(chunk.op)(chunk.op.lhs, rhs)
-            elif np.isscalar(chunk.op.rhs):
-                lhs = _evaluate(chunk.op.lhs, input_dict)
-                return _get_jax_function(chunk.op)(lhs, chunk.op.rhs)
+    @ft.partial(jax.jit, static_argnums=(1,))
+    def _eval(input_dict, chunk):
+        op_composed = chunk.composed
+        env = input_dict
+
+        def read(key):
+            return env[key]
+
+        def write(key, value):
+            env[key] = value
+
+        for comp in op_composed:
+            op_type = type(comp.op)
+            # eval unary
+            if op_type in UNARY_ARITHMETIC_SUPPORT:
+                # get input
+                data = read(comp.op.input.key)
+                res = _get_jax_function(comp.op)(data)
+                write(comp.op.outputs[0].key, res)
+
+            # eval binary
+            elif op_type in BINARY_ARITHMETIC_SUPPORT:
+                if hasattr(comp.op, "lhs"):
+                    if hasattr(comp.op.lhs, "key"):
+                        lhs = read(comp.op.lhs.key)
+                    else:
+                        lhs = comp.op.lhs
+                if hasattr(comp.op, "rhs"):
+                    if hasattr(comp.op.rhs, "key"):
+                        rhs = read(comp.op.rhs.key)
+                    else:
+                        rhs = comp.op.rhs
+                res = _get_jax_function(comp.op)(lhs, rhs)
+                write(comp.op.outputs[0].key, res)
+
+            # eval reduction
+            elif op_type in REDUCTION_SUPPORT:
+                # get input
+                ax = comp.op.axis
+                data = read(comp.op.input.key)
+                if len(ax) == data.ndim:
+                    res = _get_jax_function(comp.op)(data)
+                else:
+                    res = _get_jax_function(comp.op)(data, axis=ax)
+                write(comp.op.outputs[0].key, res)
+            # eval tree
+            elif op_type in TREE_SUPPORT:
+                func = _get_jax_function(comp.op)
+                inputs = [read(input.key) for input in comp.inputs]
+                res = func(inputs[0], inputs[1])
+                for input in inputs[2:]:
+                    res = func(res, input)
+                write(comp.op.outputs[0].key, res)
             else:
-                lhs = _evaluate(chunk.op.lhs, input_dict)
-                rhs = _evaluate(chunk.op.rhs, input_dict)
-                return _get_jax_function(chunk.op)(lhs, rhs)
-        return _get_jax_function(chunk.op)
-    elif op_type in TREE_SUPPORT:
-        func = _get_jax_function(chunk.op)
-        inputs = [_evaluate(input, input_dict) for input in chunk.inputs]
+                raise TypeError(f"unsupported operator in jax: {op_type.__name__}")
 
-        # passing func and inputs as parameters seems to cause error with jax.jit
-        def _fusion():
-            output = func(inputs[0], inputs[1])
-            for input in inputs[2:]:
-                output = func(output, input)
-            return output
+        return read(chunk.op.outputs[0].key)
 
-        return jax.jit(_fusion)()
-    elif op_type in REDUCTION_SUPPORT:
-        ax = chunk.op.axis
-        data = _evaluate(chunk.inputs[0], input_dict)
-        if len(ax) == data.ndim:
-            return _get_jax_function(chunk.op)(data)
-        else:
-            return _get_jax_function(chunk.op)(data, axis=ax)
-    else:
-        raise TypeError(f"unsupported operator in jax: {op_type.__name__}")
+else:
+
+    def _eval(input_dict, chunk):
+        raise ImportError("jax is not installed")
 
 
 def _get_jax_function(operand):
@@ -99,11 +120,11 @@ def _get_jax_function(operand):
 def _maybe_keepdims(chunk, res):
     out_chunk = chunk.composed[-1] if type(chunk.op) == TensorJAXFuseChunk else chunk
     if type(out_chunk.op) in REDUCTION_SUPPORT and out_chunk.op.keepdims:
-        res = np.reshape(res, out_chunk.shape)
+        res = jnp.reshape(res, out_chunk.shape)
     return res
 
 
-ARITHMETIC_SUPPORT = {
+UNARY_ARITHMETIC_SUPPORT = {
     arithmetic.TensorNegative,
     arithmetic.TensorAbs,
     arithmetic.TensorConj,
@@ -128,6 +149,9 @@ ARITHMETIC_SUPPORT = {
     arithmetic.TensorFloor,
     arithmetic.TensorCeil,
     arithmetic.TensorNot,
+}
+
+BINARY_ARITHMETIC_SUPPORT = {
     arithmetic.TensorAdd,
     arithmetic.TensorSubtract,
     arithmetic.TensorMultiply,


### PR DESCRIPTION
Modify original PR https://github.com/xorbitsai/xorbits/pull/440, which doesn't make full use of the compilation of `jax`, 

## What do these changes do?

this PR re-implements the core `_evaluate` function, referring to https://jax.readthedocs.io/en/latest/autodidax.html#part-2-jaxprs, this PR add a no-recursive and fully jittable `_eval` function.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
