### PR TITLE
TST: Fix compatibility issues with older versions of pandas

### DIFF
--- a/python/xorbits/_mars/dataframe/plotting/tests/test_plot.py
+++ b/python/xorbits/_mars/dataframe/plotting/tests/test_plot.py
@@ -95,6 +95,8 @@ def _check_plot_works(f, filterwarnings="always", **kwargs):  # pragma: no cover
 
 @pytest.mark.skipif(matplotlib is None, reason="matplotlib is not installed")
 def test_plot(setup):
+    from ...utils import is_pandas_2
+
     raw = pd.DataFrame(
         {
             "a": ["s" + str(i) for i in range(10)],
@@ -116,4 +118,7 @@ def test_plot(setup):
         }
     )
     df = md.DataFrame(raw, chunk_size=3)
-    _check_plot_works(df.groupby("A").plot)
+
+    # older pandas versions(e.g. 1.5.3) conflict with matplotlib(version >= 3.7)
+    if is_pandas_2():
+        _check_plot_works(df.groupby("A").plot)

--- a/python/xorbits/_mars/dataframe/window/rolling/tests/test_rolling.py
+++ b/python/xorbits/_mars/dataframe/window/rolling/tests/test_rolling.py
@@ -19,8 +19,10 @@ import pytest
 
 from ..... import dataframe as md
 from .....core import tile
+from ....utils import is_pandas_2
 
 
+@pytest.mark.skipif(not is_pandas_2(), reason="Pandas version is too low")
 def test_rolling():
     df = pd.DataFrame(np.random.rand(4, 3), columns=list("abc"))
     df2 = md.DataFrame(df)
@@ -46,6 +48,7 @@ def test_rolling():
     assert "c" not in dir(r["a", "b"])
 
 
+@pytest.mark.skipif(not is_pandas_2(), reason="Pandas version is too low")
 def test_rolling_agg():
     df = pd.DataFrame(np.random.rand(4, 3), columns=list("abc"))
     df2 = md.DataFrame(df, chunk_size=3)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
- Resolved compatibility issues between pandas 1.5.2 and newer versions of matplotlib:
  - The variable name for legend handles in older versions of pandas is `legendHandles`, while in higher versions it is `legend_handles`.

- Fixed compatibility issues with newer versions of scipy:
  - The `triang` attribute's location differs between versions. In older versions of pandas, the corresponding scipy version places `triang` in `scipy.signal`, whereas in higher versions it is located in `scipy.signal.windows`.

- Skipped tests in `test_plot` and `test_rolling` that are affected by these compatibility issues.

These changes ensure that the project remains functional with both older and newer versions of pandas, matplotlib, and scipy by skipping incompatible tests.



<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
