### PR TITLE
BUG: fix compatibility issue of df.sort_index() and df.groupby(sort=True)

### DIFF
--- a/python/xorbits/_mars/dataframe/groupby/sort.py
+++ b/python/xorbits/_mars/dataframe/groupby/sort.py
@@ -122,20 +122,20 @@ class DataFrameGroupbySortShuffle(MapReduceOperand, DataFrameOperandMixin):
             if p_index == 0:
                 out_df = in_df.loc[: pivots[p_index]]
             elif p_index == op.n_partition - 1:
-                # in_df may not have the index in pivot
-                # return an empty dataframe
+                # in_df may not have the index in pivots, and throw ZeroDivisionError
+                # in this case, just return an empty dataframe
                 try:
                     out_df = in_df.loc[pivots[p_index - 1] :].drop(
                         index=pivots[p_index - 1], errors="ignore"
                     )
-                except Exception:
+                except ZeroDivisionError:
                     out_df = pd.DataFrame(columns=in_df.columns)
             else:
                 try:
                     out_df = in_df.loc[pivots[p_index - 1] : pivots[p_index]].drop(
                         index=pivots[p_index - 1], errors="ignore"
                     )
-                except Exception:
+                except ZeroDivisionError:
                     out_df = pd.DataFrame(columns=in_df.columns)
             return out_df
 

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -289,6 +289,8 @@ def test_sort_values_execution(setup, distinct_opt):
 
 
 def test_sort_index_execution(setup):
+    from ...utils import is_pandas_2
+
     raw = pd.DataFrame(np.random.rand(100, 20), index=np.random.rand(100))
 
     mdf = DataFrame(raw)
@@ -341,13 +343,11 @@ def test_sort_index_execution(setup):
 
     mdf = DataFrame(raw, chunk_size=4)
 
-    result = mdf.sort_index(axis=1, ignore_index=True).execute().fetch()
-    try:  # for python3.5
+    # behavior of sort_index(axis=1, ignore_index=True) change after 2.0
+    if is_pandas_2():
+        result = mdf.sort_index(axis=1, ignore_index=True).execute().fetch()
         expected = raw.sort_index(axis=1, ignore_index=True)
-    except TypeError:
-        expected = raw.sort_index(axis=1)
-        expected.index = pd.RangeIndex(len(expected))
-    pd.testing.assert_frame_equal(result, expected)
+        pd.testing.assert_frame_equal(result, expected)
 
     # test series
     raw = pd.Series(np.random.rand(10), index=np.random.rand(10))


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

### sort_index

Xorbits' DataFrame `sort_index` is inconsistent with pandas when `axis=1` and `ignore_index=True`.
pandas does it by sorting the index as usual and replacing index (when axis=0) or columns (when axis=1) with RangeIndex.
[Here](https://github.com/pandas-dev/pandas/blob/8b705675bcb8ae86fb03e388e9969a1772236bf0/pandas/core/generic.py#L5032) is the reference code.

So here we follow pandas  and replace index or columns when `ignore_index=True` is passed.

### groupby(sort=True).agg()

`python/xorbits/_mars/dataframe/groupby/sort.py`:

```python
out_df = in_df.loc[pivots[p_index - 1] :].drop(
                    index=pivots[p_index - 1], errors="ignore"
                )
```

In the latest version, during the map phase of DataFrameGroupbySortShuffle, if `in_df` does not contain the index from pivots, an empty `out_df` is returned.

## Related issue number

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
