### PR TITLE
CHORE: limit numpy<2.0 as xorbits is not fully prepared for it 

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -139,7 +139,7 @@ jobs:
       if: ${{ matrix.module != 'gpu' }}
       run: |
         pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
-        pip install numpy scipy cython pyftpdlib coverage flaky "numexpr<2.8.5"
+        pip install "numpy<2.0.0" scipy cython pyftpdlib coverage flaky "numexpr<2.8.5"
 
         if [[ "$MODULE" == "xorbits" ]]; then
           pip install openpyxl

--- a/CI/requirements-wheel.txt
+++ b/CI/requirements-wheel.txt
@@ -6,6 +6,8 @@ pandas==1.2.2; python_version>='3.9' and python_version<'3.10'
 pandas==1.3.4; python_version>='3.10' and python_version<'3.11'
 pandas==1.5.0; python_version>='3.11'
 
+numpy<2.0.0
+
 scipy==1.4.1; python_version<'3.9' and platform_machine!='aarch64'
 scipy==1.5.3; python_version<'3.9' and platform_machine=='aarch64'
 scipy==1.5.4; python_version>='3.9' and python_version<'3.10'

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -24,7 +24,7 @@ include_package_data = True
 packages = find:
 install_requires =
     xoscar>=0.0.8
-    numpy>=1.14.0
+    numpy>=1.14.0,<2.0.0
     pandas>=1.0.0
     scipy>=1.0.0; sys_platform!="win32" or python_version>="3.10"
     scipy>=1.0.0,<=1.9.1; sys_platform=="win32" and python_version<"3.10"

--- a/python/xorbits/_mars/serialization/serializables/field_type.py
+++ b/python/xorbits/_mars/serialization/serializables/field_type.py
@@ -60,7 +60,7 @@ _primitive_type_to_valid_types = {
     PrimitiveType.float32: (float, np.float32),
     PrimitiveType.float64: (float, np.float64),
     PrimitiveType.bytes: (bytes, np.bytes_),
-    PrimitiveType.string: (str, np.str_),
+    PrimitiveType.string: (str, np.unicode_),
     PrimitiveType.complex64: (complex, np.complex64),
     PrimitiveType.complex128: (complex, np.complex128),
 }

--- a/python/xorbits/_mars/serialization/serializables/field_type.py
+++ b/python/xorbits/_mars/serialization/serializables/field_type.py
@@ -60,7 +60,7 @@ _primitive_type_to_valid_types = {
     PrimitiveType.float32: (float, np.float32),
     PrimitiveType.float64: (float, np.float64),
     PrimitiveType.bytes: (bytes, np.bytes_),
-    PrimitiveType.string: (str, np.unicode_),
+    PrimitiveType.string: (str, np.str_),
     PrimitiveType.complex64: (complex, np.complex64),
     PrimitiveType.complex128: (complex, np.complex128),
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

xorbits is not fully prepared for numpy 2.0. limit numpy version in CI.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #781 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
