### PR TITLE
ENH: support cudf Buffer BufferOwner structure

### DIFF
--- a/python/xorbits/_mars/_utils.pyx
+++ b/python/xorbits/_mars/_utils.pyx
@@ -286,7 +286,7 @@ def tokenize_cupy(ob):
 def tokenize_cudf(ob):
     from xoscar.serialization import serialize
     header, buffers = serialize(ob)
-    return iterative_tokenize([header] + [(buf.ptr, buf.size) for buf in buffers])
+    return iterative_tokenize([header] + [(buf._owner._ptr, buf.size) for buf in buffers])
 
 
 cdef Tokenizer tokenize_handler = Tokenizer()


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

cudf update its Buffer memory structure. It adds a `BufferOwner` structure.
See https://github.com/rapidsai/cudf/blob/branch-24.08/python/cudf/cudf/core/buffer/buffer.py
This PR make Xorbits compatible with the latest cudf memory structure.


## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass
