### PR TITLE
BLD: Fix slurm CI/CD workflow

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    # if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,31 +62,31 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:
       CONDA_ENV: xorbits-test
+      SELF_HOST_PYTHON: /root/miniconda3/bin/python
+      SELF_HOST_CONDA: /root/miniconda3/bin/conda
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
-        module: ["xorbits", "kubernetes"]
+        module: ["xorbits", "xorbits/numpy", "xorbits/pandas", "kubernetes"]
         exclude:
-          - { os: macos-latest, python-version: 3.10}
-          - { os: macos-latest, python-version: 3.9}
+          - { os: macos-13, python-version: 3.10}
+          - { os: macos-13, python-version: 3.9}
           - { os: windows-latest, python-version: 3.10}
           - { os: windows-latest, python-version: 3.9}
           - { os: windows-latest, module: kubernetes}
-          - { os: macos-latest, module: kubernetes}
+          - { os: macos-13, module: kubernetes}
         include:
           - { os: ubuntu-latest, module: _mars/dataframe, python-version: 3.9 }
-          - { os: ubuntu-latest, module: _mars/tensor, python-version: 3.9 }
-          - { os: ubuntu-latest, module: _mars/learn, python-version: 3.9 }
           - { os: ubuntu-latest, module: learn, python-version: 3.9 }
           - { os: ubuntu-latest, module: mars-core, python-version: 3.9 }
           - { os: ubuntu-20.04, module: hadoop, python-version: 3.9 }
@@ -94,7 +94,7 @@ jobs:
           - { os: ubuntu-latest, module: external-storage, python-version: 3.9 }
           - { os: ubuntu-latest, module: compatibility, python-version: 3.9 }
           - { os: ubuntu-latest, module: doc-build, python-version: 3.9 }
-          - { os: self-hosted, module: gpu, python-version: 3.9}
+          - { os: [self-hosted, gpu], module: gpu, python-version: 3.11}
           - { os: ubuntu-latest, module: jax, python-version: 3.9 }
           - { os: juicefs-ci, module: kubernetes-juicefs, python-version: 3.9 }
           - { os: ubuntu-latest, module: slurm, python-version: 3.9 }
@@ -126,11 +126,11 @@ jobs:
         minikube-version: 1.31.2
 
     - name: Install ucx dependencies
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.11') }}
+      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest')}}
       run: |
         conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
     - name: Install libomp (macOS)
-      if: matrix.os == 'macos-latest'
+      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-13' }}
       run: brew install libomp
     - name: Install dependencies
       env:
@@ -139,9 +139,9 @@ jobs:
       if: ${{ matrix.module != 'gpu' }}
       run: |
         pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
-        pip install "numpy<2.0.0" scipy cython pyftpdlib coverage flaky "numexpr<2.8.5"
+        pip install "numpy<2.0.0" scipy cython pyftpdlib coverage flaky numexpr
 
-        if [[ "$MODULE" == "xorbits" ]]; then
+        if [[ "$MODULE" == "xorbits/pandas" ]]; then
           pip install openpyxl
         fi
         if [[ "$MODULE" == "mars-core" ]]; then
@@ -227,9 +227,6 @@ jobs:
         if [[ "$MODULE" == "learn" ]]; then
           pip install xgboost lightgbm
         fi
-        if [[ "$MODULE" == "ray-dag" ]] || [[ "$MODULE" == "ray-deploy" ]]; then
-          pip install "xgboost_ray<0.1.14" "protobuf<4" "sqlalchemy<2"
-        fi
         if [[ "$MODULE" == "compatibility" ]]; then
           # test if compatible with older versions
           pip install "pandas==1.5.3" "scipy<=1.10.1" "numpy<=1.24.1" "matplotlib<=3.7.0" "pyarrow<12.0.0" "sqlalchemy<2"
@@ -267,6 +264,10 @@ jobs:
     - name: Install on GPU
       if: ${{ matrix.module == 'gpu' }}
       run: |
+        pip install --extra-index-url=https://pypi.nvidia.com cudf-cu12==24.8.*
+        pip install ucx-py-cu12 cython "numpy>=1.14.0,<2.0.0" cloudpickle scikit-learn \
+          pyyaml psutil tornado sqlalchemy defusedxml tqdm uvloop coverage \
+          pytest pytest-cov pytest-timeout pytest-forked pytest-asyncio pytest-mock
         pip install -U xoscar
         python setup.py build_ext -i
       working-directory: ./python
@@ -278,126 +279,128 @@ jobs:
         make html_zh_cn
       working-directory: ./doc
 
-    # - name: Test with pytest
-    #   if: ${{ matrix.module != 'doc-build' }}
-    #   env:
-    #     MODULE: ${{ matrix.module }}
-    #   run: |
-    #     if [[ "$MODULE" == "xorbits" ]]; then
-    #       pytest --ignore xorbits/_mars/ --ignore xorbits/xgboost --ignore xorbits/lightgbm \
-    #         --ignore xorbits/datasets --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
-    #     elif [[ "$MODULE" == "mars-core" ]]; then
-    #       pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
-    #         --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
-    #         --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
-    #     elif [[ "$MODULE" == "kubernetes" ]]; then
-    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
-    #     elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
-    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
-    #     elif [[ "$MODULE" == "slurm" ]]; then
-    #       docker exec c1 /bin/bash -c "pip install xorbits"
-    #       docker exec c2 /bin/bash -c "pip install xorbits"
-    #       docker exec slurmctld /bin/bash -c \
-    #       "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
-    #     elif [[ "$MODULE" == "hadoop" ]]; then
-    #       export WITH_HADOOP="1"
-    #       export HADOOP_HOME="/usr/local/hadoop"
-    #       export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-    #       export HADOOP_INSTALL=$HADOOP_HOME
-    #       export HADOOP_MAPRED_HOME=$HADOOP_HOME
-    #       export HADOOP_COMMON_HOME=$HADOOP_HOME
-    #       export HADOOP_HDFS_HOME=$HADOOP_HOME
-    #       export YARN_HOME=$HADOOP_HOME
-    #       export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
-    #       export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
-    #     elif [[ "$MODULE" == "vineyard" ]]; then
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
-    #         xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
-    #         xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
-    #     elif [[ "$MODULE" == "external-storage" ]]; then
-    #       export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
-    #       export JUICEFS_HOME="/usr/local/bin/juicefs"
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-    #     elif [[ "$MODULE" == "_mars/learn" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
-    #     elif [[ "$MODULE" == "learn" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         xorbits/xgboost xorbits/lightgbm
-    #     elif [ "$MODULE" == "ray-deploy" ]; then
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars --ignore=xorbits/_mars/deploy/oscar/ -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray.py -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_load_modules.py -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_cluster_standalone.py -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_client.py -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_fault_injection.py -m ray
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_scheduling.py -m ray
-    #     elif [ "$MODULE" == "ray-dag" ]; then
-    #       export MARS_CI_BACKEND=ray
-    #       export RAY_idle_worker_killing_time_threshold_ms=60000
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 --timeout=500 xorbits/_mars/dataframe \
-    #         -v -s -m "not skip_ray_dag" --ignore=xorbits/_mars/dataframe/contrib/raydataset
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=500 xorbits/_mars/dataframe/contrib/raydataset -v -s -m "not skip_ray_dag"
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=500 xorbits/_mars/tensor -v -s -m "not skip_ray_dag"
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=500 xorbits/_mars/learn --ignore xorbits/_mars/learn/contrib \
-    #         --ignore xorbits/_mars/learn/utils/tests/test_collect_ports.py -m "not skip_ray_dag"
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=200 xorbits -v -s -m ray_dag
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag.py
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_failover.py
-    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_oscar.py -m ray
-    #     elif [ "$MODULE" == "gpu" ]; then
-    #       pytest -m cuda --gpu --ignore xorbits/datasets --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
-    #     elif [ "$MODULE" == "jax" ]; then
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
-    #     elif [ "$MODULE" == "datasets" ]; then
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets
-    #     elif [ "$MODULE" == "compatibility" ]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
-    #     else
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
-    #     fi
-    #   working-directory: ./python
+    - name: Test with pytest
+      if: ${{ matrix.module != 'doc-build' && matrix.module != 'gpu' }}
+      env:
+        MODULE: ${{ matrix.module }}
+      run: |
+        if [[ "$MODULE" == "xorbits" ]]; then
+          pytest --ignore xorbits/_mars/ --ignore xorbits/pandas --ignore xorbits/numpy \
+            --ignore xorbits/xgboost --ignore xorbits/lightgbm --ignore xorbits/sklearn \
+            --ignore xorbits/datasets \
+            --ignore xorbits/core/tests/test_execution_exit.py \
+            --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "not test_execution_with_process_exit_message" \
+            xorbits
+          # workaround: this case will hang, run it separately.
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "test_execution_with_process_exit_message" \
+            xorbits/core/tests/test_execution.py
+        elif [[ "$MODULE" == "xorbits/pandas" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml \
+            --cov=xorbits xorbits/pandas
+        elif [[ "$MODULE" == "xorbits/numpy" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "not test_numpy_fallback" \
+            xorbits/numpy
+          # workaround: this case will hang, run it separately.
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml \
+            --cov=xorbits \
+            -k "test_numpy_fallback" \
+            xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
+        elif [[ "$MODULE" == "mars-core" ]]; then
+          pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
+            --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
+            --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
+        elif [[ "$MODULE" == "kubernetes" ]]; then
+          pytest --ignore xorbits/_mars/ --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
+        elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
+          pytest --ignore xorbits/_mars/ --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
+        elif [[ "$MODULE" == "slurm" ]]; then
+          docker exec c1 /bin/bash -c "pip install xorbits"
+          docker exec c2 /bin/bash -c "pip install xorbits"
+          docker exec slurmctld /bin/bash -c \
+          "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
+        elif [[ "$MODULE" == "hadoop" ]]; then
+          export WITH_HADOOP="1"
+          export HADOOP_HOME="/usr/local/hadoop"
+          export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+          export HADOOP_INSTALL=$HADOOP_HOME
+          export HADOOP_MAPRED_HOME=$HADOOP_HOME
+          export HADOOP_COMMON_HOME=$HADOOP_HOME
+          export HADOOP_HDFS_HOME=$HADOOP_HOME
+          export YARN_HOME=$HADOOP_HOME
+          export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
+          export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
+        elif [[ "$MODULE" == "vineyard" ]]; then
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
+            xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
+            xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
+        elif [[ "$MODULE" == "external-storage" ]]; then
+          export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+          export JUICEFS_HOME="/usr/local/bin/juicefs"
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+        elif [[ "$MODULE" == "_mars/learn" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
+        elif [[ "$MODULE" == "learn" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            xorbits/xgboost xorbits/lightgbm
+        elif [ "$MODULE" == "jax" ]; then
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
+        elif [ "$MODULE" == "datasets" ]; then
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
+        elif [ "$MODULE" == "compatibility" ]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
+        else
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
+        fi
+      working-directory: ./python
+    
+    - name: Test with pytest GPU
+      if: ${{ matrix.module == 'gpu' }}
+      run: |
+        pytest -m cuda --gpu --ignore xorbits/datasets \
+          --ignore xorbits/sklearn --ignore xorbits/_mars/learn \
+          --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+          xorbits
+      working-directory: ./python
 
 
     - name: Cleanup on slurm
@@ -407,7 +410,7 @@ jobs:
         jobqueue_after_script
 
     - name: Report coverage data
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         working-directory: ./python
         flags: unittests

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -300,96 +300,96 @@ jobs:
             --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
             -k "test_execution_with_process_exit_message" \
             xorbits/core/tests/test_execution.py
-        elif [[ "$MODULE" == "xorbits/pandas" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml \
-            --cov=xorbits xorbits/pandas
-        elif [[ "$MODULE" == "xorbits/numpy" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            -k "not test_numpy_fallback" \
-            xorbits/numpy
-          # workaround: this case will hang, run it separately.
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml \
-            --cov=xorbits \
-            -k "test_numpy_fallback" \
-            xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
-        elif [[ "$MODULE" == "mars-core" ]]; then
-          pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
-            --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
-            --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
-        elif [[ "$MODULE" == "kubernetes" ]]; then
-          pytest --ignore xorbits/_mars/ --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
-        elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
-          pytest --ignore xorbits/_mars/ --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
+        # elif [[ "$MODULE" == "xorbits/pandas" ]]; then
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml \
+        #     --cov=xorbits xorbits/pandas
+        # elif [[ "$MODULE" == "xorbits/numpy" ]]; then
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+        #     -k "not test_numpy_fallback" \
+        #     xorbits/numpy
+        #   # workaround: this case will hang, run it separately.
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml \
+        #     --cov=xorbits \
+        #     -k "test_numpy_fallback" \
+        #     xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
+        # elif [[ "$MODULE" == "mars-core" ]]; then
+        #   pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
+        #     --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
+        #     --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
+        # elif [[ "$MODULE" == "kubernetes" ]]; then
+        #   pytest --ignore xorbits/_mars/ --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
+        # elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
+        #   pytest --ignore xorbits/_mars/ --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
         elif [[ "$MODULE" == "slurm" ]]; then
           docker exec c1 /bin/bash -c "pip install xorbits"
           docker exec c2 /bin/bash -c "pip install xorbits"
           docker exec slurmctld /bin/bash -c \
           "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
-        elif [[ "$MODULE" == "hadoop" ]]; then
-          export WITH_HADOOP="1"
-          export HADOOP_HOME="/usr/local/hadoop"
-          export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-          export HADOOP_INSTALL=$HADOOP_HOME
-          export HADOOP_MAPRED_HOME=$HADOOP_HOME
-          export HADOOP_COMMON_HOME=$HADOOP_HOME
-          export HADOOP_HDFS_HOME=$HADOOP_HOME
-          export YARN_HOME=$HADOOP_HOME
-          export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
-          export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
-        elif [[ "$MODULE" == "vineyard" ]]; then
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
-            xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
-            xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
-        elif [[ "$MODULE" == "external-storage" ]]; then
-          export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
-          export JUICEFS_HOME="/usr/local/bin/juicefs"
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-        elif [[ "$MODULE" == "_mars/learn" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
-        elif [[ "$MODULE" == "learn" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            xorbits/xgboost xorbits/lightgbm
-        elif [ "$MODULE" == "jax" ]; then
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
-        elif [ "$MODULE" == "datasets" ]; then
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
-        elif [ "$MODULE" == "compatibility" ]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
-        else
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
+        # elif [[ "$MODULE" == "hadoop" ]]; then
+        #   export WITH_HADOOP="1"
+        #   export HADOOP_HOME="/usr/local/hadoop"
+        #   export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+        #   export HADOOP_INSTALL=$HADOOP_HOME
+        #   export HADOOP_MAPRED_HOME=$HADOOP_HOME
+        #   export HADOOP_COMMON_HOME=$HADOOP_HOME
+        #   export HADOOP_HDFS_HOME=$HADOOP_HOME
+        #   export YARN_HOME=$HADOOP_HOME
+        #   export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
+        #   export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
+        # elif [[ "$MODULE" == "vineyard" ]]; then
+        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
+        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
+        #     xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
+        #     xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
+        # elif [[ "$MODULE" == "external-storage" ]]; then
+        #   export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+        #   export JUICEFS_HOME="/usr/local/bin/juicefs"
+        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+        # elif [[ "$MODULE" == "_mars/learn" ]]; then
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+        #     xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
+        # elif [[ "$MODULE" == "learn" ]]; then
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+        #     xorbits/xgboost xorbits/lightgbm
+        # elif [ "$MODULE" == "jax" ]; then
+        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
+        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
+        # elif [ "$MODULE" == "datasets" ]; then
+        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
+        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
+        # elif [ "$MODULE" == "compatibility" ]; then
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
+        # else
+        #   pytest --timeout=1500 \
+        #     -W ignore::PendingDeprecationWarning \
+        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
         fi
       working-directory: ./python
     

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -279,119 +279,119 @@ jobs:
         make html_zh_cn
       working-directory: ./doc
 
-    - name: Test with pytest
-      if: ${{ matrix.module != 'doc-build' && matrix.module != 'gpu' }}
-      env:
-        MODULE: ${{ matrix.module }}
-      run: |
-        if [[ "$MODULE" == "xorbits" ]]; then
-          pytest --ignore xorbits/_mars/ --ignore xorbits/pandas --ignore xorbits/numpy \
-            --ignore xorbits/xgboost --ignore xorbits/lightgbm --ignore xorbits/sklearn \
-            --ignore xorbits/datasets \
-            --ignore xorbits/core/tests/test_execution_exit.py \
-            --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            -k "not test_execution_with_process_exit_message" \
-            xorbits
-          # workaround: this case will hang, run it separately.
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            -k "test_execution_with_process_exit_message" \
-            xorbits/core/tests/test_execution.py
-        # elif [[ "$MODULE" == "xorbits/pandas" ]]; then
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml \
-        #     --cov=xorbits xorbits/pandas
-        # elif [[ "$MODULE" == "xorbits/numpy" ]]; then
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-        #     -k "not test_numpy_fallback" \
-        #     xorbits/numpy
-        #   # workaround: this case will hang, run it separately.
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml \
-        #     --cov=xorbits \
-        #     -k "test_numpy_fallback" \
-        #     xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
-        # elif [[ "$MODULE" == "mars-core" ]]; then
-        #   pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
-        #     --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
-        #     --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
-        # elif [[ "$MODULE" == "kubernetes" ]]; then
-        #   pytest --ignore xorbits/_mars/ --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
-        # elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
-        #   pytest --ignore xorbits/_mars/ --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
-        elif [[ "$MODULE" == "slurm" ]]; then
-          docker exec c1 /bin/bash -c "pip install xorbits"
-          docker exec c2 /bin/bash -c "pip install xorbits"
-          docker exec slurmctld /bin/bash -c \
-          "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
-        # elif [[ "$MODULE" == "hadoop" ]]; then
-        #   export WITH_HADOOP="1"
-        #   export HADOOP_HOME="/usr/local/hadoop"
-        #   export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-        #   export HADOOP_INSTALL=$HADOOP_HOME
-        #   export HADOOP_MAPRED_HOME=$HADOOP_HOME
-        #   export HADOOP_COMMON_HOME=$HADOOP_HOME
-        #   export HADOOP_HDFS_HOME=$HADOOP_HOME
-        #   export YARN_HOME=$HADOOP_HOME
-        #   export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
-        #   export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
-        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
-        # elif [[ "$MODULE" == "vineyard" ]]; then
-        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
-        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
-        #     xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
-        #     xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
-        # elif [[ "$MODULE" == "external-storage" ]]; then
-        #   export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
-        #   export JUICEFS_HOME="/usr/local/bin/juicefs"
-        #   pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-        # elif [[ "$MODULE" == "_mars/learn" ]]; then
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-        #     xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
-        # elif [[ "$MODULE" == "learn" ]]; then
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-        #     xorbits/xgboost xorbits/lightgbm
-        # elif [ "$MODULE" == "jax" ]; then
-        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
-        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
-        # elif [ "$MODULE" == "datasets" ]; then
-        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
-        #   pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
-        # elif [ "$MODULE" == "compatibility" ]; then
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
-        # else
-        #   pytest --timeout=1500 \
-        #     -W ignore::PendingDeprecationWarning \
-        #     --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
-        fi
-      working-directory: ./python
+    # - name: Test with pytest
+    #   if: ${{ matrix.module != 'doc-build' && matrix.module != 'gpu' }}
+    #   env:
+    #     MODULE: ${{ matrix.module }}
+    #   run: |
+    #     if [[ "$MODULE" == "xorbits" ]]; then
+    #       pytest --ignore xorbits/_mars/ --ignore xorbits/pandas --ignore xorbits/numpy \
+    #         --ignore xorbits/xgboost --ignore xorbits/lightgbm --ignore xorbits/sklearn \
+    #         --ignore xorbits/datasets \
+    #         --ignore xorbits/core/tests/test_execution_exit.py \
+    #         --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         -k "not test_execution_with_process_exit_message" \
+    #         xorbits
+    #       # workaround: this case will hang, run it separately.
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         -k "test_execution_with_process_exit_message" \
+    #         xorbits/core/tests/test_execution.py
+    #     elif [[ "$MODULE" == "xorbits/pandas" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml \
+    #         --cov=xorbits xorbits/pandas
+    #     elif [[ "$MODULE" == "xorbits/numpy" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         -k "not test_numpy_fallback" \
+    #         xorbits/numpy
+    #       # workaround: this case will hang, run it separately.
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml \
+    #         --cov=xorbits \
+    #         -k "test_numpy_fallback" \
+    #         xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
+    #     elif [[ "$MODULE" == "mars-core" ]]; then
+    #       pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
+    #         --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
+    #         --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
+    #     elif [[ "$MODULE" == "kubernetes" ]]; then
+    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
+    #     elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
+    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
+    #     elif [[ "$MODULE" == "slurm" ]]; then
+    #       docker exec c1 /bin/bash -c "pip install xorbits"
+    #       docker exec c2 /bin/bash -c "pip install xorbits"
+    #       docker exec slurmctld /bin/bash -c \
+    #       "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
+    #     elif [[ "$MODULE" == "hadoop" ]]; then
+    #       export WITH_HADOOP="1"
+    #       export HADOOP_HOME="/usr/local/hadoop"
+    #       export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+    #       export HADOOP_INSTALL=$HADOOP_HOME
+    #       export HADOOP_MAPRED_HOME=$HADOOP_HOME
+    #       export HADOOP_COMMON_HOME=$HADOOP_HOME
+    #       export HADOOP_HDFS_HOME=$HADOOP_HOME
+    #       export YARN_HOME=$HADOOP_HOME
+    #       export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
+    #       export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
+    #     elif [[ "$MODULE" == "vineyard" ]]; then
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
+    #         xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
+    #         xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
+    #     elif [[ "$MODULE" == "external-storage" ]]; then
+    #       export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+    #       export JUICEFS_HOME="/usr/local/bin/juicefs"
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+    #     elif [[ "$MODULE" == "_mars/learn" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
+    #     elif [[ "$MODULE" == "learn" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         xorbits/xgboost xorbits/lightgbm
+    #     elif [ "$MODULE" == "jax" ]; then
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
+    #     elif [ "$MODULE" == "datasets" ]; then
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
+    #     elif [ "$MODULE" == "compatibility" ]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
+    #     else
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
+    #     fi
+    #   working-directory: ./python
     
     - name: Test with pytest GPU
       if: ${{ matrix.module == 'gpu' }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    # if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:
@@ -278,126 +278,126 @@ jobs:
         make html_zh_cn
       working-directory: ./doc
 
-    - name: Test with pytest
-      if: ${{ matrix.module != 'doc-build' }}
-      env:
-        MODULE: ${{ matrix.module }}
-      run: |
-        if [[ "$MODULE" == "xorbits" ]]; then
-          pytest --ignore xorbits/_mars/ --ignore xorbits/xgboost --ignore xorbits/lightgbm \
-            --ignore xorbits/datasets --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
-        elif [[ "$MODULE" == "mars-core" ]]; then
-          pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
-            --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
-            --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
-        elif [[ "$MODULE" == "kubernetes" ]]; then
-          pytest --ignore xorbits/_mars/ --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
-        elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
-          pytest --ignore xorbits/_mars/ --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
-        elif [[ "$MODULE" == "slurm" ]]; then
-          docker exec c1 /bin/bash -c "pip install xorbits"
-          docker exec c2 /bin/bash -c "pip install xorbits"
-          docker exec slurmctld /bin/bash -c \
-          "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
-        elif [[ "$MODULE" == "hadoop" ]]; then
-          export WITH_HADOOP="1"
-          export HADOOP_HOME="/usr/local/hadoop"
-          export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-          export HADOOP_INSTALL=$HADOOP_HOME
-          export HADOOP_MAPRED_HOME=$HADOOP_HOME
-          export HADOOP_COMMON_HOME=$HADOOP_HOME
-          export HADOOP_HDFS_HOME=$HADOOP_HOME
-          export YARN_HOME=$HADOOP_HOME
-          export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
-          export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
-        elif [[ "$MODULE" == "vineyard" ]]; then
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
-            xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
-            xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
-        elif [[ "$MODULE" == "external-storage" ]]; then
-          export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
-          export JUICEFS_HOME="/usr/local/bin/juicefs"
-          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-        elif [[ "$MODULE" == "_mars/learn" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
-        elif [[ "$MODULE" == "learn" ]]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-            xorbits/xgboost xorbits/lightgbm
-        elif [ "$MODULE" == "ray-deploy" ]; then
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars --ignore=xorbits/_mars/deploy/oscar/ -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray.py -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_load_modules.py -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_cluster_standalone.py -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_client.py -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_fault_injection.py -m ray
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
-            --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_scheduling.py -m ray
-        elif [ "$MODULE" == "ray-dag" ]; then
-          export MARS_CI_BACKEND=ray
-          export RAY_idle_worker_killing_time_threshold_ms=60000
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 --timeout=500 xorbits/_mars/dataframe \
-            -v -s -m "not skip_ray_dag" --ignore=xorbits/_mars/dataframe/contrib/raydataset
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=500 xorbits/_mars/dataframe/contrib/raydataset -v -s -m "not skip_ray_dag"
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=500 xorbits/_mars/tensor -v -s -m "not skip_ray_dag"
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=500 xorbits/_mars/learn --ignore xorbits/_mars/learn/contrib \
-            --ignore xorbits/_mars/learn/utils/tests/test_collect_ports.py -m "not skip_ray_dag"
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=200 xorbits -v -s -m ray_dag
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag.py
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_failover.py
-          pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
-            --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_oscar.py -m ray
-        elif [ "$MODULE" == "gpu" ]; then
-          pytest -m cuda --gpu --ignore xorbits/datasets --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
-        elif [ "$MODULE" == "jax" ]; then
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
-        elif [ "$MODULE" == "datasets" ]; then
-          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets
-        elif [ "$MODULE" == "compatibility" ]; then
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
-        else
-          pytest --timeout=1500 \
-            -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
-        fi
-      working-directory: ./python
+    # - name: Test with pytest
+    #   if: ${{ matrix.module != 'doc-build' }}
+    #   env:
+    #     MODULE: ${{ matrix.module }}
+    #   run: |
+    #     if [[ "$MODULE" == "xorbits" ]]; then
+    #       pytest --ignore xorbits/_mars/ --ignore xorbits/xgboost --ignore xorbits/lightgbm \
+    #         --ignore xorbits/datasets --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
+    #     elif [[ "$MODULE" == "mars-core" ]]; then
+    #       pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
+    #         --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
+    #         --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
+    #     elif [[ "$MODULE" == "kubernetes" ]]; then
+    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
+    #     elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
+    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
+    #     elif [[ "$MODULE" == "slurm" ]]; then
+    #       docker exec c1 /bin/bash -c "pip install xorbits"
+    #       docker exec c2 /bin/bash -c "pip install xorbits"
+    #       docker exec slurmctld /bin/bash -c \
+    #       "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
+    #     elif [[ "$MODULE" == "hadoop" ]]; then
+    #       export WITH_HADOOP="1"
+    #       export HADOOP_HOME="/usr/local/hadoop"
+    #       export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+    #       export HADOOP_INSTALL=$HADOOP_HOME
+    #       export HADOOP_MAPRED_HOME=$HADOOP_HOME
+    #       export HADOOP_COMMON_HOME=$HADOOP_HOME
+    #       export HADOOP_HDFS_HOME=$HADOOP_HOME
+    #       export YARN_HOME=$HADOOP_HOME
+    #       export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
+    #       export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
+    #     elif [[ "$MODULE" == "vineyard" ]]; then
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
+    #         xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
+    #         xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
+    #     elif [[ "$MODULE" == "external-storage" ]]; then
+    #       export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+    #       export JUICEFS_HOME="/usr/local/bin/juicefs"
+    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+    #     elif [[ "$MODULE" == "_mars/learn" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
+    #     elif [[ "$MODULE" == "learn" ]]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+    #         xorbits/xgboost xorbits/lightgbm
+    #     elif [ "$MODULE" == "ray-deploy" ]; then
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars --ignore=xorbits/_mars/deploy/oscar/ -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray.py -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_load_modules.py -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_cluster_standalone.py -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_client.py -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_fault_injection.py -m ray
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits --durations=0 \
+    #         --log-level=DEBUG --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_scheduling.py -m ray
+    #     elif [ "$MODULE" == "ray-dag" ]; then
+    #       export MARS_CI_BACKEND=ray
+    #       export RAY_idle_worker_killing_time_threshold_ms=60000
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 --timeout=500 xorbits/_mars/dataframe \
+    #         -v -s -m "not skip_ray_dag" --ignore=xorbits/_mars/dataframe/contrib/raydataset
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=500 xorbits/_mars/dataframe/contrib/raydataset -v -s -m "not skip_ray_dag"
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=500 xorbits/_mars/tensor -v -s -m "not skip_ray_dag"
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=500 xorbits/_mars/learn --ignore xorbits/_mars/learn/contrib \
+    #         --ignore xorbits/_mars/learn/utils/tests/test_collect_ports.py -m "not skip_ray_dag"
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=200 xorbits -v -s -m ray_dag
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag.py
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_failover.py
+    #       pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
+    #         --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_oscar.py -m ray
+    #     elif [ "$MODULE" == "gpu" ]; then
+    #       pytest -m cuda --gpu --ignore xorbits/datasets --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits
+    #     elif [ "$MODULE" == "jax" ]; then
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
+    #     elif [ "$MODULE" == "datasets" ]; then
+    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets
+    #     elif [ "$MODULE" == "compatibility" ]; then
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
+    #     else
+    #       pytest --timeout=1500 \
+    #         -W ignore::PendingDeprecationWarning \
+    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
+    #     fi
+    #   working-directory: ./python
 
 
     - name: Cleanup on slurm

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:
@@ -279,119 +279,119 @@ jobs:
         make html_zh_cn
       working-directory: ./doc
 
-    # - name: Test with pytest
-    #   if: ${{ matrix.module != 'doc-build' && matrix.module != 'gpu' }}
-    #   env:
-    #     MODULE: ${{ matrix.module }}
-    #   run: |
-    #     if [[ "$MODULE" == "xorbits" ]]; then
-    #       pytest --ignore xorbits/_mars/ --ignore xorbits/pandas --ignore xorbits/numpy \
-    #         --ignore xorbits/xgboost --ignore xorbits/lightgbm --ignore xorbits/sklearn \
-    #         --ignore xorbits/datasets \
-    #         --ignore xorbits/core/tests/test_execution_exit.py \
-    #         --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         -k "not test_execution_with_process_exit_message" \
-    #         xorbits
-    #       # workaround: this case will hang, run it separately.
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         -k "test_execution_with_process_exit_message" \
-    #         xorbits/core/tests/test_execution.py
-    #     elif [[ "$MODULE" == "xorbits/pandas" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml \
-    #         --cov=xorbits xorbits/pandas
-    #     elif [[ "$MODULE" == "xorbits/numpy" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         -k "not test_numpy_fallback" \
-    #         xorbits/numpy
-    #       # workaround: this case will hang, run it separately.
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml \
-    #         --cov=xorbits \
-    #         -k "test_numpy_fallback" \
-    #         xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
-    #     elif [[ "$MODULE" == "mars-core" ]]; then
-    #       pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
-    #         --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
-    #         --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
-    #     elif [[ "$MODULE" == "kubernetes" ]]; then
-    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
-    #     elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
-    #       pytest --ignore xorbits/_mars/ --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
-    #     elif [[ "$MODULE" == "slurm" ]]; then
-    #       docker exec c1 /bin/bash -c "pip install xorbits"
-    #       docker exec c2 /bin/bash -c "pip install xorbits"
-    #       docker exec slurmctld /bin/bash -c \
-    #       "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
-    #     elif [[ "$MODULE" == "hadoop" ]]; then
-    #       export WITH_HADOOP="1"
-    #       export HADOOP_HOME="/usr/local/hadoop"
-    #       export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
-    #       export HADOOP_INSTALL=$HADOOP_HOME
-    #       export HADOOP_MAPRED_HOME=$HADOOP_HOME
-    #       export HADOOP_COMMON_HOME=$HADOOP_HOME
-    #       export HADOOP_HDFS_HOME=$HADOOP_HOME
-    #       export YARN_HOME=$HADOOP_HOME
-    #       export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
-    #       export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
-    #     elif [[ "$MODULE" == "vineyard" ]]; then
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
-    #         xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
-    #         xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
-    #     elif [[ "$MODULE" == "external-storage" ]]; then
-    #       export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
-    #       export JUICEFS_HOME="/usr/local/bin/juicefs"
-    #       pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
-    #     elif [[ "$MODULE" == "_mars/learn" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
-    #     elif [[ "$MODULE" == "learn" ]]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
-    #         xorbits/xgboost xorbits/lightgbm
-    #     elif [ "$MODULE" == "jax" ]; then
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
-    #     elif [ "$MODULE" == "datasets" ]; then
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
-    #       pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
-    #     elif [ "$MODULE" == "compatibility" ]; then
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
-    #     else
-    #       pytest --timeout=1500 \
-    #         -W ignore::PendingDeprecationWarning \
-    #         --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
-    #     fi
-    #   working-directory: ./python
+    - name: Test with pytest
+      if: ${{ matrix.module != 'doc-build' && matrix.module != 'gpu' }}
+      env:
+        MODULE: ${{ matrix.module }}
+      run: |
+        if [[ "$MODULE" == "xorbits" ]]; then
+          pytest --ignore xorbits/_mars/ --ignore xorbits/pandas --ignore xorbits/numpy \
+            --ignore xorbits/xgboost --ignore xorbits/lightgbm --ignore xorbits/sklearn \
+            --ignore xorbits/datasets \
+            --ignore xorbits/core/tests/test_execution_exit.py \
+            --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "not test_execution_with_process_exit_message" \
+            xorbits
+          # workaround: this case will hang, run it separately.
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "test_execution_with_process_exit_message" \
+            xorbits/core/tests/test_execution.py
+        elif [[ "$MODULE" == "xorbits/pandas" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml \
+            --cov=xorbits xorbits/pandas
+        elif [[ "$MODULE" == "xorbits/numpy" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            -k "not test_numpy_fallback" \
+            xorbits/numpy
+          # workaround: this case will hang, run it separately.
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml \
+            --cov=xorbits \
+            -k "test_numpy_fallback" \
+            xorbits/numpy/numpy_adapters/tests/test_numpy_adapters.py
+        elif [[ "$MODULE" == "mars-core" ]]; then
+          pytest --forked --log-level=DEBUG --ignore xorbits/_mars/dataframe --ignore xorbits/_mars/tensor \
+            --ignore xorbits/_mars/learn --ignore xorbits/_mars/remote \
+            --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars
+        elif [[ "$MODULE" == "kubernetes" ]]; then
+          pytest --ignore xorbits/_mars/ --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes
+        elif [[ "$MODULE" == "kubernetes-juicefs" ]]; then
+          pytest --ignore xorbits/_mars/ --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/kubernetes/external_storage/juicefs
+        elif [[ "$MODULE" == "slurm" ]]; then
+          docker exec c1 /bin/bash -c "pip install xorbits"
+          docker exec c2 /bin/bash -c "pip install xorbits"
+          docker exec slurmctld /bin/bash -c \
+          "pytest /xorbits/python/xorbits/deploy/slurm/tests/test_slurm.py "
+        elif [[ "$MODULE" == "hadoop" ]]; then
+          export WITH_HADOOP="1"
+          export HADOOP_HOME="/usr/local/hadoop"
+          export CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath --glob`
+          export HADOOP_INSTALL=$HADOOP_HOME
+          export HADOOP_MAPRED_HOME=$HADOOP_HOME
+          export HADOOP_COMMON_HOME=$HADOOP_HOME
+          export HADOOP_HDFS_HOME=$HADOOP_HOME
+          export YARN_HOME=$HADOOP_HOME
+          export HADOOP_COMMON_LIB_NATIVE_DIR="$HADOOP_HOME/lib/native"
+          export PATH="$PATH:$HADOOP_HOME/sbin:$HADOOP_HOME/bin"
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning xorbits/_mars -m hadoop
+        elif [[ "$MODULE" == "vineyard" ]]; then
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/deploy/oscar/tests/test_local.py
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits -k "vineyard" \
+            xorbits/_mars/tensor/datastore/tests/test_datastore_execution.py \
+            xorbits/_mars/dataframe/datastore/tests/test_datastore_execution.py
+        elif [[ "$MODULE" == "external-storage" ]]; then
+          export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+          export JUICEFS_HOME="/usr/local/bin/juicefs"
+          pytest --timeout=1500 -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/storage/tests/test_libs.py
+        elif [[ "$MODULE" == "_mars/learn" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            xorbits/$MODULE xorbits/_mars/contrib/dask/tests/test_dask.py
+        elif [[ "$MODULE" == "learn" ]]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
+            xorbits/xgboost xorbits/lightgbm
+        elif [ "$MODULE" == "jax" ]; then
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/fuse/tests/test_runtime_fusion.py
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/_mars/tensor/
+        elif [ "$MODULE" == "datasets" ]; then
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/backends
+          pytest --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/datasets/tests
+        elif [ "$MODULE" == "compatibility" ]; then
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/dataframe
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/_mars/services/storage
+        else
+          pytest --timeout=1500 \
+            -W ignore::PendingDeprecationWarning \
+            --cov-config=setup.cfg --cov-report=xml --cov=xorbits/deploy --cov=xorbits xorbits/$MODULE
+        fi
+      working-directory: ./python
     
     - name: Test with pytest GPU
       if: ${{ matrix.module == 'gpu' }}

--- a/CI/slurm/Dockerfile
+++ b/CI/slurm/Dockerfile
@@ -1,2 +1,3 @@
 FROM daskdev/dask-jobqueue:slurm
-RUN pip install xorbits
+
+ENTRYPOINT ["conda", "run", "-n", "dask-jobqueue", "/bin/bash", "-c"]

--- a/CI/slurm/Dockerfile
+++ b/CI/slurm/Dockerfile
@@ -1,3 +1,2 @@
 FROM daskdev/dask-jobqueue:slurm
-
-ENTRYPOINT ["conda", "run", "-n", "dask-jobqueue"]
+# RUN pip install xorbits

--- a/CI/slurm/Dockerfile
+++ b/CI/slurm/Dockerfile
@@ -1,2 +1,7 @@
 FROM daskdev/dask-jobqueue:slurm
-# RUN pip install xorbits
+
+SHELL ["/bin/bash", "-c"]
+
+# activate conda env
+RUN echo "source /opt/anaconda/bin/activate dask-jobqueue" >> ~/.bashrc
+ENV PATH /opt/anaconda/envs/dask-jobqueue/bin:$PATH

--- a/CI/slurm/Dockerfile
+++ b/CI/slurm/Dockerfile
@@ -1,3 +1,3 @@
 FROM daskdev/dask-jobqueue:slurm
 
-ENTRYPOINT ["conda", "run", "-n", "dask-jobqueue", "/bin/bash", "-c"]
+ENTRYPOINT ["conda", "run", "-n", "dask-jobqueue"]

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       common-network:
 
   slurmdbd:
-    image: daskdev/dask-jobqueue:slurm
+    image: slurmbase
     build: .
     command: ["slurmdbd"]
     container_name: slurmdbd
@@ -33,7 +33,7 @@ services:
       common-network:
 
   slurmctld:
-    image: daskdev/dask-jobqueue:slurm
+    image: slurmbase
     build: .
     command: ["slurmctld"]
     container_name: slurmctld
@@ -58,7 +58,7 @@ services:
       - NET_ADMIN
 
   c1:
-    image: daskdev/dask-jobqueue:slurm
+    image: slurmbase
     build: .
     command: ["slurmd"]
     hostname: c1
@@ -81,7 +81,7 @@ services:
       - NET_ADMIN
 
   c2:
-    image: daskdev/dask-jobqueue:slurm
+    image: slurmbase
     build: .
     command: ["slurmd"]
     hostname: c2

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       common-network:
 
   slurmdbd:
+    image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmdbd"]
     container_name: slurmdbd
@@ -32,6 +33,7 @@ services:
       common-network:
 
   slurmctld:
+    image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmctld"]
     container_name: slurmctld
@@ -56,6 +58,7 @@ services:
       - NET_ADMIN
 
   c1:
+    image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmd"]
     hostname: c1
@@ -78,6 +81,7 @@ services:
       - NET_ADMIN
 
   c2:
+    image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmd"]
     hostname: c2

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -16,8 +16,7 @@ services:
       common-network:
 
   slurmdbd:
-    # image: daskdev/dask-jobqueue:slurm
-    build: .
+    image: slurmbase
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -33,8 +32,7 @@ services:
       common-network:
 
   slurmctld:
-    # image: daskdev/dask-jobqueue:slurm
-    build: .
+    image: slurmbase
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -58,8 +56,7 @@ services:
       - NET_ADMIN
 
   c1:
-    # image: daskdev/dask-jobqueue:slurm
-    build: .
+    image: slurmbase
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -81,8 +78,7 @@ services:
       - NET_ADMIN
 
   c2:
-    # image: daskdev/dask-jobqueue:slurm
-    build: .
+    image: slurmbase
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       common-network:
 
   slurmdbd:
-    image: daskdev/dask-jobqueue:slurm
+    # image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmdbd"]
     container_name: slurmdbd
@@ -33,7 +33,7 @@ services:
       common-network:
 
   slurmctld:
-    image: daskdev/dask-jobqueue:slurm
+    # image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmctld"]
     container_name: slurmctld
@@ -58,7 +58,7 @@ services:
       - NET_ADMIN
 
   c1:
-    image: daskdev/dask-jobqueue:slurm
+    # image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmd"]
     hostname: c1
@@ -81,7 +81,7 @@ services:
       - NET_ADMIN
 
   c2:
-    image: daskdev/dask-jobqueue:slurm
+    # image: daskdev/dask-jobqueue:slurm
     build: .
     command: ["slurmd"]
     hostname: c2

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       common-network:
 
   slurmdbd:
-    image: slurmbase
+    build: .
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -32,7 +32,7 @@ services:
       common-network:
 
   slurmctld:
-    image: slurmbase
+    build: .
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -56,7 +56,7 @@ services:
       - NET_ADMIN
 
   c1:
-    image: slurmbase
+    build: .
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -78,7 +78,7 @@ services:
       - NET_ADMIN
 
   c2:
-    image: slurmbase
+    build: .
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/CI/slurm/docker-compose.yml
+++ b/CI/slurm/docker-compose.yml
@@ -17,7 +17,6 @@ services:
 
   slurmdbd:
     image: slurmbase
-    build: .
     command: ["slurmdbd"]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -34,7 +33,6 @@ services:
 
   slurmctld:
     image: slurmbase
-    build: .
     command: ["slurmctld"]
     container_name: slurmctld
     hostname: slurmctld
@@ -59,7 +57,6 @@ services:
 
   c1:
     image: slurmbase
-    build: .
     command: ["slurmd"]
     hostname: c1
     container_name: c1
@@ -82,7 +79,6 @@ services:
 
   c2:
     image: slurmbase
-    build: .
     command: ["slurmd"]
     hostname: c2
     container_name: c2

--- a/CI/slurm/register_cluster.sh
+++ b/CI/slurm/register_cluster.sh
@@ -2,4 +2,4 @@
 set -e
 
 docker exec slurmctld bash -c "/usr/bin/sacctmgr --immediate add cluster name=linux" && \
-docker-compose restart slurmdbd slurmctld
+docker compose restart slurmdbd slurmctld

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -15,7 +15,7 @@
 
 function jobqueue_before_install {
     docker version
-    docker-compose version
+    docker compose version
 
     # start slurm cluster
     cd ./CI/slurm

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -43,14 +43,14 @@ function show_network_interfaces {
 }
 
 function jobqueue_install {
-    docker exec slurmctld /bin/bash -c "cd xorbits/python/; pip install -e ."
+    docker exec slurmctld /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; cd xorbits/python/; pip install -e ."
 }
 
 function jobqueue_script {
-    docker exec c1 /bin/bash -c "pip install xorbits"
-    docker exec c2 /bin/bash -c "pip install xorbits"
+    docker exec c1 /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; pip install xorbits"
+    docker exec c2 /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; pip install xorbits"
     docker exec slurmctld /bin/bash -c \
-          "pytest --ignore xorbits/_mars/ --timeout=1500 \
+          "source /opt/anaconda/bin/activate dask-jobqueue; pytest --ignore xorbits/_mars/ --timeout=1500 \
             -W ignore::PendingDeprecationWarning \
             --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/slurm"
 }

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -19,7 +19,8 @@ function jobqueue_before_install {
 
     # start slurm cluster
     cd ./CI/slurm
-    docker compose pull
+    docker build -t slurmbase .
+    docker compose up
     ./start-slurm.sh
     cd -
 

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -43,14 +43,14 @@ function show_network_interfaces {
 }
 
 function jobqueue_install {
-    docker exec slurmctld /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; cd xorbits/python/; pip install -e ."
+    docker exec slurmctld /bin/bash -c "cd xorbits/python/; pip install -e ."
 }
 
 function jobqueue_script {
-    docker exec c1 /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; pip install xorbits"
-    docker exec c2 /bin/bash -c "source /opt/anaconda/bin/activate dask-jobqueue; pip install xorbits"
+    docker exec c1 /bin/bash -c "pip install xorbits"
+    docker exec c2 /bin/bash -c "pip install xorbits"
     docker exec slurmctld /bin/bash -c \
-          "source /opt/anaconda/bin/activate dask-jobqueue; pytest --ignore xorbits/_mars/ --timeout=1500 \
+          "pytest --ignore xorbits/_mars/ --timeout=1500 \
             -W ignore::PendingDeprecationWarning \
             --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits/deploy/slurm"
 }

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -35,6 +35,7 @@ function show_network_interfaces {
     for c in slurmctld c1 c2; do
         echo '------------------------------------------------------------'
         echo docker container: $c
+        docker exec $c pip install psutil
         docker exec $c python -c 'import psutil; print(psutil.net_if_addrs().keys())'
         echo '------------------------------------------------------------'
     done

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -19,11 +19,12 @@ function jobqueue_before_install {
 
     # start slurm cluster
     cd ./CI/slurm
+    docker build -t slurmbase .
     docker compose pull
     ./start-slurm.sh
     cd -
 
-    #Set shared space permissions
+    # set shared space permissions
     docker exec slurmctld /bin/bash -c "chmod -R 777 /shared_space"
 
     docker ps -a

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -20,7 +20,6 @@ function jobqueue_before_install {
     # start slurm cluster
     cd ./CI/slurm
     docker build -t slurmbase .
-    docker compose up
     ./start-slurm.sh
     cd -
 

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -19,7 +19,7 @@ function jobqueue_before_install {
 
     # start slurm cluster
     cd ./CI/slurm
-    docker-compose pull
+    docker compose pull
     ./start-slurm.sh
     cd -
 

--- a/CI/slurm/slurm.sh
+++ b/CI/slurm/slurm.sh
@@ -19,7 +19,6 @@ function jobqueue_before_install {
 
     # start slurm cluster
     cd ./CI/slurm
-    docker build -t slurmbase .
     docker compose pull
     ./start-slurm.sh
     cd -

--- a/CI/slurm/start-slurm.sh
+++ b/CI/slurm/start-slurm.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-docker-compose up -d --no-build
+docker compose up -d --no-build
 
 while [ `./register_cluster.sh 2>&1 | grep "sacctmgr: error" | wc -l` -ne 0 ]
   do


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
- The previous setup relied on the default `base` environment provided by the conda environment in the image `daskdev/dask-jobqueue:slurm`. 
- However, the intended environment is `dask-jobqueue`. 
- To ensure the correct environment is used, a new custom `slurmbase` image is now manually created, and the `dask-jobqueue` environment is activated within the image.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
