### PR TITLE
BLD: Fix upload PyPI

### DIFF
--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           package-dir: ./python/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: wheelhouse/*.whl
 
@@ -109,7 +109,7 @@ jobs:
       - name: Build sdist
         run: cd python && pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           path: ./python/dist/*.tar.gz
 
@@ -119,7 +119,7 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '30 7 * * *'
+    - cron: '12 8 * * *'
   push:
     tags:
       - '*'

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '12 8 * * *'
+    - cron: '30 4 * * *'
   push:
     tags:
       - '*'
@@ -117,7 +117,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '30 4 * * *'
+    - cron: '30 7 * * *'
   push:
     tags:
       - '*'
@@ -88,7 +88,7 @@ jobs:
         with:
           package-dir: ./python/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
 
@@ -109,7 +109,7 @@ jobs:
       - name: Build sdist
         run: cd python && pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./python/dist/*.tar.gz
 
@@ -117,16 +117,16 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
           name: artifact
           path: dist
 
-      # if is xprobe repo, upload to pypi
+      # if is xorbits repo, upload to pypi
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.repository == 'xorbitsai/xorbits'
         with:
@@ -134,7 +134,7 @@ jobs:
           password: ${{ secrets.PYPI_PASSWORD }}
           skip-existing: true
 
-      # if is not xprobe repo, upload to test
+      # if is not xorbits repo, upload to test
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.repository != 'xorbitsai/xorbits'
         with:


### PR DESCRIPTION
Rollback download-artifact and upload-artifact to v3.
v4 has breaking changes, see https://github.com/actions/upload-artifact/issues/478.