### PR TITLE
DOC: URLs link to original lightgbm and xgboost docs

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -8,5 +8,7 @@ API Reference
    :maxdepth: 2
 
    xorbits/index
+   lightgbm/index
+   xgboost/index
    datasets/index
    experimental/index

--- a/doc/source/reference/lightgbm/learning.rst
+++ b/doc/source/reference/lightgbm/learning.rst
@@ -3,10 +3,25 @@
 ============
 Learning API
 ============
-.. currentmodule:: xorbits.lightgbm
 
-.. autosummary::
-    :toctree: generated/
-    
-    predict
-    predict_proba
+The following table lists both implemented and not implemented methods. If you have need
+of an operation that is listed as not implemented, feel free to open an issue on the
+`GitHub repository`_, or give a thumbs up to already created issues. Contributions are
+also welcome!
+
+The following table is structured as follows: The first column contains the method name.
+The second column contains link to a description of corresponding lightgbm method.
+The third column is a flag for whether or not there is an implementation in Xorbits for
+the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` stands
+for partial (meaning some parameters may not be supported yet), and ``D`` stands for
+default to lightgbm.
+
++-----------------------------+-----------------------------------+------------------------+----------------------------------+
+| xorbits.lightgbm            | lightgbm                          | Implemented? (Y/N/P/D) | Notes for Current implementation |
++-----------------------------+-----------------------------------+------------------------+----------------------------------+
+
+.. Originally, `predict` and `predict_proba methods` were included,
+.. but they are not consistent with the interfaces of lightgbm.
+
+.. _`GitHub repository`: https://github.com/xorbitsai/xorbits/issues
+

--- a/doc/source/reference/lightgbm/learning.rst
+++ b/doc/source/reference/lightgbm/learning.rst
@@ -16,9 +16,11 @@ the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` 
 for partial (meaning some parameters may not be supported yet), and ``D`` stands for
 default to lightgbm.
 
-+-----------------------------+-----------------------------------+------------------------+----------------------------------+
-| xorbits.lightgbm            | lightgbm                          | Implemented? (Y/N/P/D) | Notes for Current implementation |
-+-----------------------------+-----------------------------------+------------------------+----------------------------------+
++----------------------+--------------+------------------------+----------------------------------+
+| ``xorbits.lightgbm`` | ``lightgbm`` | Implemented? (Y/N/P/D) | Notes for Current implementation |
++----------------------+--------------+------------------------+----------------------------------+
+|                      |              |                        |                                  |
++----------------------+--------------+------------------------+----------------------------------+
 
 .. Originally, `predict` and `predict_proba methods` were included,
 .. but they are not consistent with the interfaces of lightgbm.

--- a/doc/source/reference/lightgbm/sklearn.rst
+++ b/doc/source/reference/lightgbm/sklearn.rst
@@ -4,81 +4,109 @@
 Scikit-Learn API
 ================
 
+The following table lists both implemented and not implemented methods. If you have need
+of an operation that is listed as not implemented, feel free to open an issue on the
+`GitHub repository`_, or give a thumbs up to already created issues. Contributions are
+also welcome!
+
+The following table is structured as follows: The first column contains the method name.
+The second column contains link to a description of corresponding lightgbm method.
+The third column is a flag for whether or not there is an implementation in Xorbits for
+the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` stands
+for partial (meaning some parameters may not be supported yet), and ``D`` stands for
+default to lightgbm.
+
 LGBMClassifier
 ==============
-.. currentmodule:: xorbits.lightgbm
 
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    LGBMClassifier
-
-
-Attributes
-~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    LGBMClassifier.fit
-    LGBMClassifier.get_params
-    LGBMClassifier.load_model
-    LGBMClassifier.predict
-    LGBMClassifier.predict_proba
-    LGBMClassifier.score
-    LGBMClassifier.set_params
-    LGBMClassifier.to_local
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``xorbits.lightgbm``             | ``lightgbm``                    | Implemented? (Y/N/P/D) | Notes for Current implementation |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.fit``           | `LGBMClassifier.fit`_           | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.get_params``    | `LGBMClassifier.get_params`_    | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.load_model``    | `LGBMClassifier.load_model`_    | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.predict``       | `LGBMClassifier.predict`_       | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.predict_proba`` | `LGBMClassifier.predict_proba`_ | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.score``         | `LGBMClassifier.score`_         | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.set_params``    | `LGBMClassifier.set_params`_    | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
+| ``LGBMClassifier.to_local``      | `LGBMClassifier.to_local`_      | Y                      |                                  |
++----------------------------------+---------------------------------+------------------------+----------------------------------+
 
 LGBMRegressor
 =============
-.. currentmodule:: xorbits.lightgbm
 
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    LGBMRegressor
-
-
-Attributes
-~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    LGBMRegressor.fit
-    LGBMRegressor.get_params
-    LGBMRegressor.load_model
-    LGBMRegressor.predict
-    LGBMRegressor.predict_proba
-    LGBMRegressor.score
-    LGBMRegressor.set_params
-    LGBMRegressor.to_local
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``xorbits.lightgbm``            | ``lightgbm``                   | Implemented? (Y/N/P/D) | Notes for Current implementation |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.fit``           | `LGBMRegressor.fit`_           | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.get_params``    | `LGBMRegressor.get_params`_    | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.load_model``    | `LGBMRegressor.load_model`_    | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.predict``       | `LGBMRegressor.predict`_       | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.predict_proba`` | `LGBMRegressor.predict_proba`_ | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.score``         | `LGBMRegressor.score`_         | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.set_params``    | `LGBMRegressor.set_params`_    | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
+| ``LGBMRegressor.to_local``      | `LGBMRegressor.to_local`_      | Y                      |                                  |
++---------------------------------+--------------------------------+------------------------+----------------------------------+
 
 LGBMRanker
 ==========
-.. currentmodule:: xorbits.lightgbm
 
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``xorbits.lightgbm``         | ``lightgbm``                | Implemented? (Y/N/P/D) | Notes for Current implementation |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.fit``           | `LGBMRanker.fit`_           | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.get_params``    | `LGBMRanker.get_params`_    | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.load_model``    | `LGBMRanker.load_model`_    | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.predict``       | `LGBMRanker.predict`_       | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.predict_proba`` | `LGBMRanker.predict_proba`_ | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.score``         | `LGBMRanker.score`_         | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.set_params``    | `LGBMRanker.set_params`_    | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
+| ``LGBMRanker.to_local``      | `LGBMRanker.to_local`_      | Y                      |                                  |
++------------------------------+-----------------------------+------------------------+----------------------------------+
 
-    LGBMRanker
-
-
-Attributes
-~~~~~~~~~~
-.. autosummary::
-    :toctree: generated/
-
-    LGBMRanker.fit
-    LGBMRanker.get_params
-    LGBMRanker.load_model
-    LGBMRanker.predict
-    LGBMRanker.predict_proba
-    LGBMRanker.set_params
-    LGBMRanker.to_local
-
-
+.. _`GitHub repository`: https://github.com/xorbitsai/xorbits/issues
+.. _`LGBMClassifier.fit`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.fit
+.. _`LGBMClassifier.get_params` : https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.get_params
+.. _`LGBMClassifier.load_model`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.load_model
+.. _`LGBMClassifier.predict`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.predict
+.. _`LGBMClassifier.predict_proba`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.predict_proba
+.. _`LGBMClassifier.score`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.score
+.. _`LGBMClassifier.set_params`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.set_params
+.. _`LGBMClassifier.to_local`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMClassifier.html#lightgbm.LGBMClassifier.to_local
+.. _`LGBMRegressor.fit`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.fit
+.. _`LGBMRegressor.get_params`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.get_params
+.. _`LGBMRegressor.load_model`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.load_model
+.. _`LGBMRegressor.predict`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.predict
+.. _`LGBMRegressor.predict_proba`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.predict_proba
+.. _`LGBMRegressor.score`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.score
+.. _`LGBMRegressor.set_params`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.set_params
+.. _`LGBMRegressor.to_local`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html#lightgbm.LGBMRegressor.to_local
+.. _`LGBMRanker.fit`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.fit
+.. _`LGBMRanker.get_params`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.get_params
+.. _`LGBMRanker.load_model`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.load_model
+.. _`LGBMRanker.predict`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.predict
+.. _`LGBMRanker.predict_proba`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.predict_proba
+.. _`LGBMRanker.score`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.score
+.. _`LGBMRanker.set_params`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.set_params
+.. _`LGBMRanker.to_local`: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRanker.html#lightgbm.LGBMRanker.to_local

--- a/doc/source/reference/xgboost/core.rst
+++ b/doc/source/reference/xgboost/core.rst
@@ -3,10 +3,23 @@
 ===================
 Core Data Structure
 ===================
-.. currentmodule:: xorbits.xgboost
 
+The following table lists both implemented and not implemented methods. If you have need
+of an operation that is listed as not implemented, feel free to open an issue on the
+`GitHub repository`_, or give a thumbs up to already created issues. Contributions are
+also welcome!
 
-.. autosummary::
-   :toctree: generated/
+The following table is structured as follows: The first column contains the method name.
+The second column contains link to a description of corresponding xgboost method.
+The third column is a flag for whether or not there is an implementation in Xorbits
+for the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` standsfor partial 
+(meaning some parameters may not be supported yet), and ``D`` stands for default to xgboost.
 
-   DMatrix
++---------------------+-------------+------------------------+----------------------------------+
+| ``xorbits.xgboost`` | ``xgboost`` | Implemented? (Y/N/P/D) | Notes for Current implementation |
++---------------------+-------------+------------------------+----------------------------------+
+| ``DMatrix``         | `DMatrix`_  | Y                      |                                  |
++---------------------+-------------+------------------------+----------------------------------+
+
+.. _`GitHub repository`: https://github.com/xorbitsai/xorbits/issues
+.. _`DMatrix`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.DMatrix

--- a/doc/source/reference/xgboost/learning_api.rst
+++ b/doc/source/reference/xgboost/learning_api.rst
@@ -3,11 +3,26 @@
 ============
 Learning API
 ============
-.. currentmodule:: xorbits.xgboost
 
+The following table lists both implemented and not implemented methods. If you have need
+of an operation that is listed as not implemented, feel free to open an issue on the
+`GitHub repository`_, or give a thumbs up to already created issues. Contributions are
+also welcome!
 
-.. autosummary::
-   :toctree: generated/
+The following table is structured as follows: The first column contains the method name.
+The second column contains link to a description of corresponding xgboost method.
+The third column is a flag for whether or not there is an implementation in Xorbits
+for the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` standsfor partial 
+(meaning some parameters may not be supported yet), and ``D`` stands for default to xgboost.
 
-   train
-   predict
++---------------------+-------------+------------------------+----------------------------------+
+| ``xorbits.xgboost`` | ``xgboost`` | Implemented? (Y/N/P/D) | Notes for Current implementation |
++---------------------+-------------+------------------------+----------------------------------+
+| ``train``           | `train`_    | Y                      |                                  |
++---------------------+-------------+------------------------+----------------------------------+
+
+.. Originally, `predict` was included,
+.. but it is not consistent with the interface of xgboost.
+
+.. _`GitHub repository`: https://github.com/xorbitsai/xorbits/issues
+.. _`train`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train

--- a/doc/source/reference/xgboost/sklearn.rst
+++ b/doc/source/reference/xgboost/sklearn.rst
@@ -4,62 +4,101 @@
 Scikit-Learn API
 ================
 
+The following table lists both implemented and not implemented methods. If you have need
+of an operation that is listed as not implemented, feel free to open an issue on the
+`GitHub repository`_, or give a thumbs up to already created issues. Contributions are
+also welcome!
+
+The following table is structured as follows: The first column contains the method name.
+The second column contains link to a description of corresponding xgboost method.
+The third column is a flag for whether or not there is an implementation in Xorbits
+for the method in the left column. ``Y`` stands for yes, ``N`` stands for no, ``P`` standsfor partial 
+(meaning some parameters may not be supported yet), and ``D`` stands for default to xgboost.
+
 XGBRegressor
 ============
-.. currentmodule:: xorbits.xgboost
 
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
-
-   XGBRegressor
-
-Attributes
-~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   XGBRegressor.apply
-   XGBRegressor.evals_result
-   XGBRegressor.fit
-   XGBRegressor.get_booster
-   XGBRegressor.get_num_boosting_rounds
-   XGBRegressor.get_params
-   XGBRegressor.get_xgb_params
-   XGBRegressor.load_model
-   XGBRegressor.predict
-   XGBRegressor.save_model
-   XGBRegressor.set_params
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``xorbits.xgboost``                      | ``xgboost``                             | Implemented? (Y/N/P/D) | Notes for Current implementation |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.apply``                   | `XGBRegressor.apply`_                   | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.evals_result``            | `XGBRegressor.evals_result`_            | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.fit``                     | `XGBRegressor.fit`_                     | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.get_booster``             | `XGBRegressor.get_booster`_             | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.get_num_boosting_rounds`` | `XGBRegressor.get_num_boosting_rounds`_ | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.get_params``              | `XGBRegressor.get_params`_              | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.get_xgb_params``          | `XGBRegressor.get_xgb_params`_          | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.load_model``              | `XGBRegressor.load_model`_              | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.predict``                 | `XGBRegressor.predict`_                 | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.save_model``              | `XGBRegressor.save_model`_              | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
+| ``XGBRegressor.set_params``              | `XGBRegressor.set_params`_              | Y                      |                                  |
++------------------------------------------+-----------------------------------------+------------------------+----------------------------------+
 
 XGBClassifier
 =============
-.. currentmodule:: xorbits.xgboost
 
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``xorbits.xgboost``                       | ``xgboost``                              | Implemented? (Y/N/P/D) | Notes for Current implementation |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.apply``                   | `XGBClassifier.apply`_                   | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.evals_result``            | `XGBClassifier.evals_result`_            | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.fit``                     | `XGBClassifier.fit`_                     | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.get_booster``             | `XGBClassifier.get_booster`_             | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.get_num_boosting_rounds`` | `XGBClassifier.get_num_boosting_rounds`_ | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.get_params``              | `XGBClassifier.get_params`_              | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.get_xgb_params``          | `XGBClassifier.get_xgb_params`_          | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.load_model``              | `XGBClassifier.load_model`_              | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.predict``                 | `XGBClassifier.predict`_                 | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.predict_proba``           | `XGBClassifier.predict_proba`_           | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.save_model``              | `XGBClassifier.save_model`_              | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.score``                   | `XGBClassifier.score`_                   | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
+| ``XGBClassifier.set_params``              | `XGBClassifier.set_params`_              | Y                      |                                  |
++-------------------------------------------+------------------------------------------+------------------------+----------------------------------+
 
-   XGBClassifier
-
-Attributes
-~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   XGBClassifier.apply
-   XGBClassifier.evals_result
-   XGBClassifier.fit
-   XGBClassifier.get_booster
-   XGBClassifier.get_num_boosting_rounds
-   XGBClassifier.get_params
-   XGBClassifier.get_xgb_params
-   XGBClassifier.load_model
-   XGBClassifier.predict
-   XGBClassifier.predict_proba
-   XGBClassifier.save_model
-   XGBClassifier.score
-   XGBClassifier.set_params
+.. _`GitHub repository`: https://github.com/xorbitsai/xorbits/issues
+.. _`XGBRegressor.apply`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.apply
+.. _`XGBRegressor.evals_result`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.evals_result
+.. _`XGBRegressor.fit`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.fit
+.. _`XGBRegressor.get_booster`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.get_booster
+.. _`XGBRegressor.get_num_boosting_rounds`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.get_num_boosting_rounds
+.. _`XGBRegressor.get_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.get_params
+.. _`XGBRegressor.get_xgb_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.get_xgb_params
+.. _`XGBRegressor.load_model`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.load_model
+.. _`XGBRegressor.predict`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.predict
+.. _`XGBRegressor.save_model`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.save_model
+.. _`XGBRegressor.set_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor.set_params
+.. _`XGBClassifier.apply`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.apply
+.. _`XGBClassifier.evals_result`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.evals_result
+.. _`XGBClassifier.fit`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.fit
+.. _`XGBClassifier.get_booster`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.get_booster
+.. _`XGBClassifier.get_num_boosting_rounds`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.get_num_boosting_rounds
+.. _`XGBClassifier.get_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.get_params
+.. _`XGBClassifier.get_xgb_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.get_xgb_params
+.. _`XGBClassifier.load_model`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.load_model
+.. _`XGBClassifier.predict`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.predict
+.. _`XGBClassifier.predict_proba`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.predict_proba
+.. _`XGBClassifier.save_model`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.save_model
+.. _`XGBClassifier.score`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.score
+.. _`XGBClassifier.set_params`: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier.set_params


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
- add a comparison table for the APIs of LightGBM and XGBoost. 
- The table provides a side-by-side reference of commonly used methods for both libraries, including links to their respective documentation pages. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
