### PR TITLE
BUG:  fix xoscar.errors.NoIdleSlot when using new_cluster

### DIFF
--- a/python/xorbits/_mars/deploy/oscar/local.py
+++ b/python/xorbits/_mars/deploy/oscar/local.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import logging
 import os
 import sys
@@ -408,7 +409,7 @@ class LocalCluster:
                 worker_pool.external_address,
                 self.supervisor_address,
                 band_to_resource,
-                config=self._config,
+                config=copy.deepcopy(self._config),
             )
 
     async def stop(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## How to Reproduce

Run the code below on device with GPU.

```
def main():
    async def fun():
        await new_cluster(
            n_worker=2,
            n_cpu=12,
            use_uvloop=False,
        )
    asyncio.run(fun())


if __name__ == "__main__":
    main()
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass
