### PR TITLE
BUG: set column name when using `xorbits.pandas.Index`

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    # if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/python/xorbits/_mars/dataframe/datasource/index.py
+++ b/python/xorbits/_mars/dataframe/datasource/index.py
@@ -65,7 +65,9 @@ class IndexDataSource(DataFrameOperand, DataFrameOperandMixin):
                 None,
                 shape=shape,
                 dtype=self.dtype,
-                index_value=parse_index(self.data, store_data=self.store_data),
+                # `store_data=True` to make sure
+                # when the `to_pandas()` is called, we can get the actual pandas value.
+                index_value=parse_index(self.data, store_data=True),
                 name=name,
                 names=names,
                 raw_chunk_size=chunk_size,

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -339,11 +339,40 @@ def test_getitem(setup):
     pd.testing.assert_frame_equal(result.to_pandas(), expected)
 
 
+def test_column_setitem(setup):
+    import pandas as pd
+
+    from ... import pandas as xpd
+
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    df = pd.DataFrame(data)
+    xdf = xpd.DataFrame(data)
+
+    xdf.columns = xpd.Index(["c1", "d1"])
+    df.columns = pd.Index(["c1", "d1"])
+    pd.testing.assert_frame_equal(xdf.to_pandas(), df)
+
+    xdf.columns = ["c2", "d2"]
+    df.columns = ["c2", "d2"]
+    pd.testing.assert_frame_equal(xdf.to_pandas(), df)
+
+    xdf.columns = pd.Index(["c3", "d3"])
+    df.columns = pd.Index(["c3", "d3"])
+    pd.testing.assert_frame_equal(xdf.to_pandas(), df)
+
+    xdf.index = ["x1", "y1", "z1"]
+    df.index = ["x1", "y1", "z1"]
+    pd.testing.assert_frame_equal(xdf.to_pandas(), df)
+
+    xdf.index = xpd.Index(["x2", "y2", "z2"])
+    df.index = pd.Index(["x2", "y2", "z2"])
+    pd.testing.assert_frame_equal(xdf.to_pandas(), df)
+
+
 # TODO: process exit cause hang
 # def test_execution_with_process_exit_message(mocker):
 #     import numpy as np
 #     from xoscar.errors import ServerClosed
-
 #     import xorbits
 #     import xorbits.remote as xr
 

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -339,7 +339,7 @@ def test_getitem(setup):
     pd.testing.assert_frame_equal(result.to_pandas(), expected)
 
 
-def test_column_setitem(setup):
+def test_column_index_setitem(setup):
     import pandas as pd
 
     from ... import pandas as xpd


### PR DESCRIPTION
Without this PR, this example will raise an error:
```
import xorbits.pandas as xpd

data = {"a": [1, 2, 3], "b": [4, 5, 6]}
xdf = xpd.DataFrame(data)

xdf.columns = xpd.Index(["c1", "d1"])
print(xdf)
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass