### PR TITLE
ENH: upgrade CI tests to python>=3.10

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    # if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - '*'
-  pull_request:
-    types: ['opened', 'reopened', 'synchronize']
+  # pull_request:
+  #   types: ['opened', 'reopened', 'synchronize']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -77,14 +77,12 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        module: ["xorbits", "xorbits/numpy", "xorbits/pandas"]
+        module: ["xorbits"]
         exclude:
           - { os: macos-14, python-version: 3.10}
           - { os: macos-14, python-version: 3.9}
           - { os: windows-latest, python-version: 3.10}
           - { os: windows-latest, python-version: 3.9}
-          - { os: windows-latest, module: kubernetes}
-          - { os: macos-14, module: kubernetes}
         include:
           - { os: ubuntu-latest, module: _mars/dataframe, python-version: "3.11" }
           - { os: ubuntu-latest, module: learn, python-version: "3.11" }
@@ -157,11 +155,8 @@ jobs:
           pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[doc]"
         else
           pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
-          pip install -U numpy scipy cython pyftpdlib coverage flaky numexpr
+          pip install -U numpy scipy cython pyftpdlib coverage flaky numexpr openpyxl
 
-          if [[ "$MODULE" == "xorbits/pandas" ]]; then
-            pip install openpyxl
-          fi
           if [[ "$MODULE" == "mars-core" ]]; then
             pip install oss2
           fi
@@ -313,12 +308,12 @@ jobs:
             -W ignore::PendingDeprecationWarning \
             --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
             xorbits
-        elif [[ "$MODULE" == "xorbits/pandas" ]]; then
+          # xorbits/pandas
           pytest --timeout=1500 \
             -W ignore::PendingDeprecationWarning \
             --cov-config=setup.cfg --cov-report=xml \
             --cov=xorbits xorbits/pandas
-        elif [[ "$MODULE" == "xorbits/numpy" ]]; then
+          # xorbits/numpy
           pytest --timeout=1500 \
             -W ignore::PendingDeprecationWarning \
             --cov-config=setup.cfg --cov-report=xml --cov=xorbits \

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -86,20 +86,21 @@ jobs:
           - { os: windows-latest, module: kubernetes}
           - { os: macos-14, module: kubernetes}
         include:
-          - { os: ubuntu-latest, module: _mars/dataframe, python-version: 3.11 }
-          - { os: ubuntu-latest, module: learn, python-version: 3.11 }
-          - { os: ubuntu-latest, module: mars-core, python-version: 3.11 }
-          - { os: ubuntu-20.04, module: hadoop, python-version: 3.10 }
-          - { os: ubuntu-latest, module: vineyard, python-version: 3.11 }
-          - { os: ubuntu-latest, module: external-storage, python-version: 3.11 }
-          - { os: ubuntu-latest, module: doc-build, python-version: 3.11 }
-          - { os: self-hosted, module: gpu, python-version: 3.11}
-          - { os: ubuntu-latest, module: jax, python-version: 3.10 }
-          - { os: ubuntu-latest, module: datasets, python-version: 3.10 }
-          # - { os: ubuntu-latest, module: kubernetes, python-version: 3.11 }
+          - { os: ubuntu-latest, module: _mars/dataframe, python-version: "3.11" }
+          - { os: ubuntu-latest, module: learn, python-version: "3.11" }
+          - { os: ubuntu-latest, module: mars-core, python-version: "3.11" }
+          - { os: ubuntu-20.04, module: hadoop, python-version: "3.10" }
+          - { os: ubuntu-latest, module: vineyard, python-version: "3.11" }
+          - { os: ubuntu-latest, module: external-storage, python-version: "3.11" }
+          - { os: ubuntu-latest, module: doc-build, python-version: "3.11" }
+          - { os: self-hosted, module: gpu, python-version: "3.11" }
+          - { os: ubuntu-latest, module: jax, python-version: "3.10" }
+          - { os: ubuntu-latest, module: datasets, python-version: "3.10" }
           # a self-hosted runner which needs computing resources, activate when necessary
           # - { os: juicefs-ci, module: kubernetes-juicefs, python-version: 3.9 }
+          # TODO: slurm & kubernetes tests are not stable
           # - { os: ubuntu-latest, module: slurm, python-version: 3.9 }
+          # - { os: ubuntu-latest, module: kubernetes, python-version: 3.11 }
           # always test compatibility with the latest version
           # - { os: ubuntu-latest, module: compatibility, python-version: 3.9 }
     steps:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -86,17 +86,17 @@ jobs:
           - { os: windows-latest, module: kubernetes}
           - { os: macos-14, module: kubernetes}
         include:
-          - { os: ubuntu-latest, module: _mars/dataframe, python-version: 3.9 }
-          - { os: ubuntu-latest, module: learn, python-version: 3.9 }
-          - { os: ubuntu-latest, module: mars-core, python-version: 3.9 }
-          - { os: ubuntu-20.04, module: hadoop, python-version: 3.9 }
+          - { os: ubuntu-latest, module: _mars/dataframe, python-version: 3.11 }
+          - { os: ubuntu-latest, module: learn, python-version: 3.11 }
+          - { os: ubuntu-latest, module: mars-core, python-version: 3.11 }
+          - { os: ubuntu-20.04, module: hadoop, python-version: 3.10 }
           - { os: ubuntu-latest, module: vineyard, python-version: 3.11 }
           - { os: ubuntu-latest, module: external-storage, python-version: 3.11 }
-          - { os: ubuntu-latest, module: doc-build, python-version: 3.9 }
+          - { os: ubuntu-latest, module: doc-build, python-version: 3.11 }
           - { os: self-hosted, module: gpu, python-version: 3.11}
-          - { os: ubuntu-latest, module: jax, python-version: 3.9 }
-          - { os: ubuntu-latest, module: datasets, python-version: 3.9 }
-          - { os: ubuntu-latest, module: kubernetes, python-version: 3.11 }
+          - { os: ubuntu-latest, module: jax, python-version: 3.10 }
+          - { os: ubuntu-latest, module: datasets, python-version: 3.10 }
+          # - { os: ubuntu-latest, module: kubernetes, python-version: 3.11 }
           # a self-hosted runner which needs computing resources, activate when necessary
           # - { os: juicefs-ci, module: kubernetes-juicefs, python-version: 3.9 }
           # - { os: ubuntu-latest, module: slurm, python-version: 3.9 }

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,7 +3,7 @@ name: Python CI
 on:
   push:
     branches:
-      - '**'
+      - '*'
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
 
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,9 +3,9 @@ name: Python CI
 on:
   push:
     branches:
-      - '*'
-  # pull_request:
-  #   types: ['opened', 'reopened', 'synchronize']
+      - '**'
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/python/xorbits/_mars/lib/sparse/tests/test_sparse.py
+++ b/python/xorbits/_mars/lib/sparse/tests/test_sparse.py
@@ -54,13 +54,13 @@ def test_sparse_creation():
     s = SparseNDArray(s1_data)
     assert s.ndim == 2
     assert isinstance(s, SparseMatrix)
-    assert_array_equal(s.toarray(), s1_data.A)
-    assert_array_equal(s.todense(), s1_data.A)
+    assert_array_equal(s.toarray(), s1_data.toarray())
+    assert_array_equal(s.todense(), s1_data.todense())
 
     ss = pickle.loads(pickle.dumps(s))
     assert s == ss
-    assert_array_equal(ss.toarray(), s1_data.A)
-    assert_array_equal(ss.todense(), s1_data.A)
+    assert_array_equal(ss.toarray(), s1_data.toarray())
+    assert_array_equal(ss.todense(), s1_data.todense())
 
     v = SparseNDArray(v1, shape=(3,))
     assert s.ndim
@@ -330,12 +330,12 @@ def test_sparse_dot():
 
     assert_array_equal(mls.dot(s1, v1_s), s1.dot(v1_data))
     assert_array_equal(mls.dot(s2, v1_s), s2.dot(v1_data))
-    assert_array_equal(mls.dot(v2_s, s1), v2_data.dot(s1_data.A))
-    assert_array_equal(mls.dot(v2_s, s2), v2_data.dot(s2_data.A))
+    assert_array_equal(mls.dot(v2_s, s1), v2_data.dot(s1_data.toarray()))
+    assert_array_equal(mls.dot(v2_s, s2), v2_data.dot(s2_data.toarray()))
     assert_array_equal(mls.dot(v1_s, v1_s), v1_data.dot(v1_data), almost=True)
     assert_array_equal(mls.dot(v2_s, v2_s), v2_data.dot(v2_data), almost=True)
 
-    assert_array_equal(mls.dot(v2_s, s1, sparse=False), v2_data.dot(s1_data.A))
+    assert_array_equal(mls.dot(v2_s, s1, sparse=False), v2_data.dot(s1_data.toarray()))
     assert_array_equal(mls.dot(v1_s, v1_s, sparse=False), v1_data.dot(v1_data))
 
 
@@ -389,7 +389,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(3)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, 3)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -398,7 +398,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(3, wrap=True)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, 3, wrap=True)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -407,7 +407,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal([1, 2, 3])
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, [1, 2, 3])
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -416,7 +416,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal([1, 2, 3], wrap=True)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, [1, 2, 3], wrap=True)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -426,7 +426,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(val)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, val)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -436,7 +436,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(val, wrap=True)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, val, wrap=True)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -446,7 +446,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(val)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, val)
 
     np.testing.assert_array_equal(arr.toarray(), expected)
@@ -456,7 +456,7 @@ def test_sparse_fill_diagonal():
     arr = SparseNDArray(s1)
     arr.fill_diagonal(val, wrap=True)
 
-    expected = s1.copy().A
+    expected = s1.copy().toarray()
     np.fill_diagonal(expected, val, wrap=True)
 
     np.testing.assert_array_equal(arr.toarray(), expected)

--- a/python/xorbits/_mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/python/xorbits/_mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -67,20 +67,20 @@ class FakeClusterAPI(ClusterAPI):
     async def create(cls, address: str, **kw):
         dones, _ = await asyncio.wait(
             [
-                mo.create_actor(
+                asyncio.create_task(mo.create_actor(
                     SupervisorPeerLocatorActor,
                     "fixed",
                     address,
                     uid=SupervisorPeerLocatorActor.default_uid(),
                     address=address,
-                ),
-                mo.create_actor(
+                )),
+                asyncio.create_task(mo.create_actor(
                     MockNodeInfoCollectorActor,
                     with_gpu=kw.get("with_gpu", False),
                     uid=NodeInfoCollectorActor.default_uid(),
                     address=address,
-                ),
-                mo.create_actor(
+                )),
+                asyncio.create_task(mo.create_actor(
                     NodeInfoUploaderActor,
                     NodeRole.WORKER,
                     interval=kw.get("upload_interval"),
@@ -88,7 +88,7 @@ class FakeClusterAPI(ClusterAPI):
                     use_gpu=kw.get("use_gpu", False),
                     uid=NodeInfoUploaderActor.default_uid(),
                     address=address,
-                ),
+                )),
             ]
         )
 

--- a/python/xorbits/_mars/services/scheduling/supervisor/tests/test_assigner.py
+++ b/python/xorbits/_mars/services/scheduling/supervisor/tests/test_assigner.py
@@ -67,28 +67,34 @@ class FakeClusterAPI(ClusterAPI):
     async def create(cls, address: str, **kw):
         dones, _ = await asyncio.wait(
             [
-                asyncio.create_task(mo.create_actor(
-                    SupervisorPeerLocatorActor,
-                    "fixed",
-                    address,
-                    uid=SupervisorPeerLocatorActor.default_uid(),
-                    address=address,
-                )),
-                asyncio.create_task(mo.create_actor(
-                    MockNodeInfoCollectorActor,
-                    with_gpu=kw.get("with_gpu", False),
-                    uid=NodeInfoCollectorActor.default_uid(),
-                    address=address,
-                )),
-                asyncio.create_task(mo.create_actor(
-                    NodeInfoUploaderActor,
-                    NodeRole.WORKER,
-                    interval=kw.get("upload_interval"),
-                    band_to_resource=kw.get("band_to_resource"),
-                    use_gpu=kw.get("use_gpu", False),
-                    uid=NodeInfoUploaderActor.default_uid(),
-                    address=address,
-                )),
+                asyncio.create_task(
+                    mo.create_actor(
+                        SupervisorPeerLocatorActor,
+                        "fixed",
+                        address,
+                        uid=SupervisorPeerLocatorActor.default_uid(),
+                        address=address,
+                    )
+                ),
+                asyncio.create_task(
+                    mo.create_actor(
+                        MockNodeInfoCollectorActor,
+                        with_gpu=kw.get("with_gpu", False),
+                        uid=NodeInfoCollectorActor.default_uid(),
+                        address=address,
+                    )
+                ),
+                asyncio.create_task(
+                    mo.create_actor(
+                        NodeInfoUploaderActor,
+                        NodeRole.WORKER,
+                        interval=kw.get("upload_interval"),
+                        band_to_resource=kw.get("band_to_resource"),
+                        use_gpu=kw.get("use_gpu", False),
+                        uid=NodeInfoUploaderActor.default_uid(),
+                        address=address,
+                    )
+                ),
             ]
         )
 

--- a/python/xorbits/_mars/services/scheduling/supervisor/tests/test_globalresource.py
+++ b/python/xorbits/_mars/services/scheduling/supervisor/tests/test_globalresource.py
@@ -70,10 +70,10 @@ async def test_global_resource(actor_pool):
     )
 
     wait_coro = global_resource_ref.wait_band_idle(band)
-    (done, pending) = await asyncio.wait([wait_coro], timeout=0.5)
+    (done, pending) = await asyncio.wait([asyncio.create_task(wait_coro)], timeout=0.5)
     assert not done
     await global_resource_ref.release_subtask_resource(band, session_id, "subtask0")
-    (done, pending) = await asyncio.wait([wait_coro], timeout=0.5)
+    (done, pending) = await asyncio.wait([asyncio.create_task(wait_coro)], timeout=0.5)
     assert done
     assert band in await global_resource_ref.get_idle_bands(0)
     assert ["subtask1"] == await global_resource_ref.apply_subtask_resources(

--- a/python/xorbits/_mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/python/xorbits/_mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -68,27 +68,33 @@ class FakeClusterAPI(ClusterAPI):
     async def create(cls, address: str, **kw):
         dones, _ = await asyncio.wait(
             [
-                asyncio.create_task(mo.create_actor(
-                    SupervisorPeerLocatorActor,
-                    "fixed",
-                    address,
-                    uid=SupervisorPeerLocatorActor.default_uid(),
-                    address=address,
-                )),
-                asyncio.create_task(mo.create_actor(
-                    MockNodeInfoCollectorActor,
-                    uid=NodeInfoCollectorActor.default_uid(),
-                    address=address,
-                )),
-                asyncio.create_task(mo.create_actor(
-                    NodeInfoUploaderActor,
-                    NodeRole.WORKER,
-                    interval=kw.get("upload_interval"),
-                    band_to_resource=kw.get("band_to_resource"),
-                    use_gpu=kw.get("use_gpu", False),
-                    uid=NodeInfoUploaderActor.default_uid(),
-                    address=address,
-                )),
+                asyncio.create_task(
+                    mo.create_actor(
+                        SupervisorPeerLocatorActor,
+                        "fixed",
+                        address,
+                        uid=SupervisorPeerLocatorActor.default_uid(),
+                        address=address,
+                    )
+                ),
+                asyncio.create_task(
+                    mo.create_actor(
+                        MockNodeInfoCollectorActor,
+                        uid=NodeInfoCollectorActor.default_uid(),
+                        address=address,
+                    )
+                ),
+                asyncio.create_task(
+                    mo.create_actor(
+                        NodeInfoUploaderActor,
+                        NodeRole.WORKER,
+                        interval=kw.get("upload_interval"),
+                        band_to_resource=kw.get("band_to_resource"),
+                        use_gpu=kw.get("use_gpu", False),
+                        uid=NodeInfoUploaderActor.default_uid(),
+                        address=address,
+                    )
+                ),
             ]
         )
 

--- a/python/xorbits/_mars/services/scheduling/supervisor/tests/test_queue_balance.py
+++ b/python/xorbits/_mars/services/scheduling/supervisor/tests/test_queue_balance.py
@@ -68,19 +68,19 @@ class FakeClusterAPI(ClusterAPI):
     async def create(cls, address: str, **kw):
         dones, _ = await asyncio.wait(
             [
-                mo.create_actor(
+                asyncio.create_task(mo.create_actor(
                     SupervisorPeerLocatorActor,
                     "fixed",
                     address,
                     uid=SupervisorPeerLocatorActor.default_uid(),
                     address=address,
-                ),
-                mo.create_actor(
+                )),
+                asyncio.create_task(mo.create_actor(
                     MockNodeInfoCollectorActor,
                     uid=NodeInfoCollectorActor.default_uid(),
                     address=address,
-                ),
-                mo.create_actor(
+                )),
+                asyncio.create_task(mo.create_actor(
                     NodeInfoUploaderActor,
                     NodeRole.WORKER,
                     interval=kw.get("upload_interval"),
@@ -88,7 +88,7 @@ class FakeClusterAPI(ClusterAPI):
                     use_gpu=kw.get("use_gpu", False),
                     uid=NodeInfoUploaderActor.default_uid(),
                     address=address,
-                ),
+                )),
             ]
         )
 

--- a/python/xorbits/_mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/python/xorbits/_mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -333,19 +333,19 @@ def test_arctan2_execution(setup):
 
     assert y.issparse() is False
     result = y.execute().fetch()
-    np.testing.assert_equal(result, np.arctan2(raw1, raw2.A))
+    np.testing.assert_equal(result, np.arctan2(raw1, raw2.toarray()))
 
     y = arctan2(raw2, raw2)
 
     assert y.issparse() is True
     result = y.execute().fetch()
-    np.testing.assert_equal(result, np.arctan2(raw2.A, raw2.A))
+    np.testing.assert_equal(result, np.arctan2(raw2.toarray(), raw2.toarray()))
 
     y = arctan2(0, raw2)
 
     assert y.issparse() is True
     result = y.execute().fetch()
-    np.testing.assert_equal(result, np.arctan2(0, raw2.A))
+    np.testing.assert_equal(result, np.arctan2(0, raw2.toarray()))
 
 
 @pytest.mark.ray_dag

--- a/python/xorbits/_mars/tensor/core.py
+++ b/python/xorbits/_mars/tensor/core.py
@@ -227,7 +227,7 @@ class TensorData(HasShapeTileableData, _ExecuteAndFetchMixin):
             print_options = np.get_printoptions()
             threshold = print_options["threshold"]
 
-            corner_data = fetch_corner_data(self, session=self._executed_sessions[-1])
+            corner_data = self.fetch(session=self._executed_sessions[-1])
             # if less than default threshold, just set it as default,
             # if not, set to corner_data.size - 1 make sure ... exists in repr
             threshold = threshold if self.size <= threshold else corner_data.size - 1

--- a/python/xorbits/_mars/tensor/core.py
+++ b/python/xorbits/_mars/tensor/core.py
@@ -43,7 +43,7 @@ from ..serialization.serializables import (
     TupleField,
 )
 from ..utils import on_deserialize_shape, on_serialize_shape
-from .utils import fetch_corner_data, get_chunk_slices
+from .utils import get_chunk_slices
 
 logger = logging.getLogger(__name__)
 

--- a/python/xorbits/_mars/tensor/indexing/tests/test_indexing_execution.py
+++ b/python/xorbits/_mars/tensor/indexing/tests/test_indexing_execution.py
@@ -719,7 +719,7 @@ def test_fill_diagonal_execution(setup):
     def copy(x):
         if hasattr(x, "nnz"):
             # sparse
-            return x.A
+            return x.toarray()
         else:
             return x.copy()
 

--- a/python/xorbits/_mars/tensor/linalg/tests/test_linalg_execution.py
+++ b/python/xorbits/_mars/tensor/linalg/tests/test_linalg_execution.py
@@ -389,7 +389,7 @@ def test_lu_execution(setup):
 
     t = P.dot(L).dot(U)
     res = t.execute().fetch()
-    np.testing.assert_array_almost_equal(data.A, res)
+    np.testing.assert_array_almost_equal(data.toarray(), res)
 
     a = tensor(data, chunk_size=5)
     P, L, U = lu(a)
@@ -404,7 +404,7 @@ def test_lu_execution(setup):
 
     t = P.dot(L).dot(U)
     res = t.execute().fetch()
-    np.testing.assert_array_almost_equal(data.A, res)
+    np.testing.assert_array_almost_equal(data.toarray(), res)
 
 
 def test_solve_triangular(setup):

--- a/python/xorbits/_mars/tensor/merge/tests/test_merge_execution.py
+++ b/python/xorbits/_mars/tensor/merge/tests/test_merge_execution.py
@@ -56,7 +56,7 @@ def test_concatenate_execution(setup):
 
     d = concatenate([a, b, c], axis=-1)
     res = d.execute().fetch()
-    expected = np.concatenate([a_data.A, b_data.A, c_data.A], axis=-1)
+    expected = np.concatenate([a_data.toarray(), b_data.toarray(), c_data.toarray()], axis=-1)
     np.testing.assert_array_equal(res.toarray(), expected)
 
 

--- a/python/xorbits/_mars/tensor/merge/tests/test_merge_execution.py
+++ b/python/xorbits/_mars/tensor/merge/tests/test_merge_execution.py
@@ -56,7 +56,9 @@ def test_concatenate_execution(setup):
 
     d = concatenate([a, b, c], axis=-1)
     res = d.execute().fetch()
-    expected = np.concatenate([a_data.toarray(), b_data.toarray(), c_data.toarray()], axis=-1)
+    expected = np.concatenate(
+        [a_data.toarray(), b_data.toarray(), c_data.toarray()], axis=-1
+    )
     np.testing.assert_array_equal(res.toarray(), expected)
 
 

--- a/python/xorbits/_mars/tensor/reduction/tests/test_reduction_execution.py
+++ b/python/xorbits/_mars/tensor/reduction/tests/test_reduction_execution.py
@@ -442,11 +442,13 @@ def test_nan_reduction(setup):
     assert pytest.approx(np.nanmean(raw.toarray())) == nanmean(arr).execute().fetch()
     assert pytest.approx(np.nanvar(raw.toarray())) == nanvar(arr).execute().fetch()
     assert (
-        pytest.approx(np.nanvar(raw.toarray(), ddof=1)) == nanvar(arr, ddof=1).execute().fetch()
+        pytest.approx(np.nanvar(raw.toarray(), ddof=1))
+        == nanvar(arr, ddof=1).execute().fetch()
     )
     assert pytest.approx(np.nanstd(raw.toarray())) == nanstd(arr).execute().fetch()
     assert (
-        pytest.approx(np.nanstd(raw.toarray(), ddof=1)) == nanstd(arr, ddof=1).execute().fetch()
+        pytest.approx(np.nanstd(raw.toarray(), ddof=1))
+        == nanstd(arr, ddof=1).execute().fetch()
     )
 
     arr = nansum(1)

--- a/python/xorbits/_mars/tensor/reduction/tests/test_reduction_execution.py
+++ b/python/xorbits/_mars/tensor/reduction/tests/test_reduction_execution.py
@@ -106,11 +106,11 @@ def test_max_min_execution(setup):
     assert raw.min() == arr.min().execute().fetch()
 
     np.testing.assert_almost_equal(
-        raw.max(axis=1).A.ravel(), arr.max(axis=1).execute().fetch().toarray()
+        raw.max(axis=1).toarray().ravel(), arr.max(axis=1).execute().fetch().toarray()
     )
     assert arr.max(axis=1).issparse() is True
     np.testing.assert_almost_equal(
-        raw.min(axis=1).A.ravel(), arr.min(axis=1).execute().fetch().toarray()
+        raw.min(axis=1).toarray().ravel(), arr.min(axis=1).execute().fetch().toarray()
     )
     assert arr.min(axis=1).issparse() is True
 
@@ -435,18 +435,18 @@ def test_nan_reduction(setup):
     raw[:3, :3] = np.nan
     arr = tensor(raw, chunk_size=6)
 
-    assert pytest.approx(np.nansum(raw.A)) == nansum(arr).execute().fetch()
-    assert pytest.approx(np.nanprod(raw.A)) == nanprod(arr).execute().fetch()
-    assert pytest.approx(np.nanmax(raw.A)) == nanmax(arr).execute().fetch()
-    assert pytest.approx(np.nanmin(raw.A)) == nanmin(arr).execute().fetch()
-    assert pytest.approx(np.nanmean(raw.A)) == nanmean(arr).execute().fetch()
-    assert pytest.approx(np.nanvar(raw.A)) == nanvar(arr).execute().fetch()
+    assert pytest.approx(np.nansum(raw.toarray())) == nansum(arr).execute().fetch()
+    assert pytest.approx(np.nanprod(raw.toarray())) == nanprod(arr).execute().fetch()
+    assert pytest.approx(np.nanmax(raw.toarray())) == nanmax(arr).execute().fetch()
+    assert pytest.approx(np.nanmin(raw.toarray())) == nanmin(arr).execute().fetch()
+    assert pytest.approx(np.nanmean(raw.toarray())) == nanmean(arr).execute().fetch()
+    assert pytest.approx(np.nanvar(raw.toarray())) == nanvar(arr).execute().fetch()
     assert (
-        pytest.approx(np.nanvar(raw.A, ddof=1)) == nanvar(arr, ddof=1).execute().fetch()
+        pytest.approx(np.nanvar(raw.toarray(), ddof=1)) == nanvar(arr, ddof=1).execute().fetch()
     )
-    assert pytest.approx(np.nanstd(raw.A)) == nanstd(arr).execute().fetch()
+    assert pytest.approx(np.nanstd(raw.toarray())) == nanstd(arr).execute().fetch()
     assert (
-        pytest.approx(np.nanstd(raw.A, ddof=1)) == nanstd(arr, ddof=1).execute().fetch()
+        pytest.approx(np.nanstd(raw.toarray(), ddof=1)) == nanstd(arr, ddof=1).execute().fetch()
     )
 
     arr = nansum(1)
@@ -471,8 +471,8 @@ def test_cum_reduction(setup):
 
     res1 = arr.cumsum(axis=1).execute().fetch()
     res2 = arr.cumprod(axis=1).execute().fetch()
-    expected1 = raw.A.cumsum(axis=1)
-    expected2 = raw.A.cumprod(axis=1)
+    expected1 = raw.toarray().cumsum(axis=1)
+    expected2 = raw.toarray().cumprod(axis=1)
     assert np.allclose(res1, expected1)
     assert np.allclose(res2, expected2)
 
@@ -530,8 +530,8 @@ def test_nan_cum_reduction(setup):
 
     res1 = nancumsum(arr, axis=1).execute().fetch()
     res2 = nancumprod(arr, axis=1).execute().fetch()
-    expected1 = np.nancumsum(raw.A, axis=1)
-    expected2 = np.nancumprod(raw.A, axis=1)
+    expected1 = np.nancumsum(raw.toarray(), axis=1)
+    expected2 = np.nancumprod(raw.toarray(), axis=1)
     assert np.allclose(res1, expected1) is True
     assert np.allclose(res2, expected2) is True
 
@@ -596,19 +596,19 @@ def test_count_nonzero_execution(setup):
     t = count_nonzero(arr)
 
     res = t.execute().fetch()
-    expected = np.count_nonzero(raw.A)
+    expected = np.count_nonzero(raw.toarray())
     np.testing.assert_equal(res, expected)
 
     t = count_nonzero(arr, axis=0)
 
     res = t.execute().fetch()
-    expected = np.count_nonzero(raw.A, axis=0)
+    expected = np.count_nonzero(raw.toarray(), axis=0)
     np.testing.assert_equal(res, expected)
 
     t = count_nonzero(arr, axis=1)
 
     res = t.execute().fetch()
-    expected = np.count_nonzero(raw.A, axis=1)
+    expected = np.count_nonzero(raw.toarray(), axis=1)
     np.testing.assert_equal(res, expected)
 
     # test string dtype

--- a/python/xorbits/_mars/tensor/statistics/histogram.py
+++ b/python/xorbits/_mars/tensor/statistics/histogram.py
@@ -367,6 +367,9 @@ def _get_bin_edges(op, a, bins, range, weights):
             yield from selector.check()
             width = selector.get_result()
             if width:
+                # Reference: https://github.com/numpy/numpy/blob/v2.1.0/numpy/lib/_histograms_impl.py#L413
+                if np.__version__ >= "2.1.0" and np.issubdtype(a.dtype, np.integer) and width < 1:
+                    width = 1
                 n_equal_bins = int(
                     np.ceil(_unsigned_subtract(last_edge, first_edge) / width)
                 )

--- a/python/xorbits/_mars/tensor/statistics/histogram.py
+++ b/python/xorbits/_mars/tensor/statistics/histogram.py
@@ -368,7 +368,11 @@ def _get_bin_edges(op, a, bins, range, weights):
             width = selector.get_result()
             if width:
                 # Reference: https://github.com/numpy/numpy/blob/v2.1.0/numpy/lib/_histograms_impl.py#L413
-                if np.__version__ >= "2.1.0" and np.issubdtype(a.dtype, np.integer) and width < 1:
+                if (
+                    np.__version__ >= "2.1.0"
+                    and np.issubdtype(a.dtype, np.integer)
+                    and width < 1
+                ):
                     width = 1
                 n_equal_bins = int(
                     np.ceil(_unsigned_subtract(last_edge, first_edge) / width)

--- a/python/xorbits/_mars/tensor/tests/test_utils.py
+++ b/python/xorbits/_mars/tensor/tests/test_utils.py
@@ -21,7 +21,8 @@ from ..utils import hash_on_axis, normalize_axis_tuple
 
 
 def test_hash_on_axis():
-    hash_from_buffer = lambda x: mmh3_hash_from_buffer(memoryview(x))
+    def hash_from_buffer(x):
+        return mmh3_hash_from_buffer(memoryview(x))
 
     a = np.random.rand(10)
 
@@ -66,27 +67,3 @@ def test_normalize_axis_tuple():
 
     with pytest.raises(ValueError):
         normalize_axis_tuple((1, -2), 3)
-
-
-# def test_fetch_tensor_corner_data(setup):
-#     print_options = np.get_printoptions()
-
-#     # make sure numpy default option
-#     assert print_options["edgeitems"] == 3
-#     assert print_options["threshold"] == 1000
-
-#     size = 12
-#     for i in (2, 4, size - 3, size, size + 3):
-#         arr = np.random.rand(i, i, i)
-#         t = mt.tensor(arr, chunk_size=size // 2)
-#         t.execute()
-
-#         corner_data = fetch_corner_data(t)
-#         corner_threshold = 1000 if t.size < 1000 else corner_data.size - 1
-#         with np.printoptions(threshold=corner_threshold, suppress=True):
-#             # when we repr corner data, we need to limit threshold that
-#             # it's exactly less than the size
-#             repr_corner_data = repr(corner_data)
-#         with np.printoptions(suppress=True):
-#             repr_result = repr(arr)
-#         assert repr_corner_data == repr_result

--- a/python/xorbits/_mars/tensor/tests/test_utils.py
+++ b/python/xorbits/_mars/tensor/tests/test_utils.py
@@ -18,7 +18,7 @@ import pytest
 
 from ... import tensor as mt
 from ...lib.mmh3 import hash_from_buffer as mmh3_hash_from_buffer
-from ..utils import fetch_corner_data, hash_on_axis, normalize_axis_tuple
+from ..utils import hash_on_axis, normalize_axis_tuple
 
 
 def test_hash_on_axis():

--- a/python/xorbits/_mars/tensor/tests/test_utils.py
+++ b/python/xorbits/_mars/tensor/tests/test_utils.py
@@ -16,7 +16,6 @@
 import numpy as np
 import pytest
 
-from ... import tensor as mt
 from ...lib.mmh3 import hash_from_buffer as mmh3_hash_from_buffer
 from ..utils import hash_on_axis, normalize_axis_tuple
 

--- a/python/xorbits/_mars/tensor/tests/test_utils.py
+++ b/python/xorbits/_mars/tensor/tests/test_utils.py
@@ -69,25 +69,25 @@ def test_normalize_axis_tuple():
         normalize_axis_tuple((1, -2), 3)
 
 
-def test_fetch_tensor_corner_data(setup):
-    print_options = np.get_printoptions()
+# def test_fetch_tensor_corner_data(setup):
+#     print_options = np.get_printoptions()
 
-    # make sure numpy default option
-    assert print_options["edgeitems"] == 3
-    assert print_options["threshold"] == 1000
+#     # make sure numpy default option
+#     assert print_options["edgeitems"] == 3
+#     assert print_options["threshold"] == 1000
 
-    size = 12
-    for i in (2, 4, size - 3, size, size + 3):
-        arr = np.random.rand(i, i, i)
-        t = mt.tensor(arr, chunk_size=size // 2)
-        t.execute()
+#     size = 12
+#     for i in (2, 4, size - 3, size, size + 3):
+#         arr = np.random.rand(i, i, i)
+#         t = mt.tensor(arr, chunk_size=size // 2)
+#         t.execute()
 
-        corner_data = fetch_corner_data(t)
-        corner_threshold = 1000 if t.size < 1000 else corner_data.size - 1
-        with np.printoptions(threshold=corner_threshold, suppress=True):
-            # when we repr corner data, we need to limit threshold that
-            # it's exactly less than the size
-            repr_corner_data = repr(corner_data)
-        with np.printoptions(suppress=True):
-            repr_result = repr(arr)
-        assert repr_corner_data == repr_result
+#         corner_data = fetch_corner_data(t)
+#         corner_threshold = 1000 if t.size < 1000 else corner_data.size - 1
+#         with np.printoptions(threshold=corner_threshold, suppress=True):
+#             # when we repr corner data, we need to limit threshold that
+#             # it's exactly less than the size
+#             repr_corner_data = repr(corner_data)
+#         with np.printoptions(suppress=True):
+#             repr_result = repr(arr)
+#         assert repr_corner_data == repr_result


### PR DESCRIPTION
## What do these changes do?

* Upgrade Python version >= 3.10 in `python.yaml` CI tests
* SciPy's sparse array `.A` is deprecated, use `.toarray()` instead
* remove `xorbits.numpy`'s `fetch_corner_data` when printing large arrays to keep compatible with NumPy 2.1+: when printing large NumPy arrays, only the corner data was printed, with the middle part replaced by an ellipsis (`...`). DO NOT need a dedicated `fetch_corner_data` method, that prints the corner data of the array, anymore.
* Update `xorbits.numpy`'s histogram to 2.1+

## Related issue number

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
