### PR TITLE
ENH: Update deprecated pandas dtype and distutils

### DIFF
--- a/python/xorbits/_mars/dataframe/indexing/tests/test_indexing.py
+++ b/python/xorbits/_mars/dataframe/indexing/tests/test_indexing.py
@@ -679,7 +679,7 @@ def test_loc_use_iloc():
     assert isinstance(df2.loc["a3":].op, DataFrameLocGetItem)
 
     raw2 = raw.copy()
-    raw2.index = [f"a{i}" for i in range(3)]
+    raw2.index = [f"idx{i}" for i in range(3)]
     df2 = md.DataFrame(raw2, chunk_size=2)
 
     assert isinstance(df2.loc[:3].op, DataFrameLocGetItem)

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -169,7 +169,7 @@ def test_sort_values_execution(setup, distinct_opt):
     # test None (issue #1885)
     df = pd.DataFrame(np.random.rand(1000, 10))
 
-    df[0] = df[0].astype('object')
+    df[0] = df[0].astype("object")
     df[0][df[0] < 0.5] = "A"
     df[0][df[0] != "A"] = None
 
@@ -263,7 +263,7 @@ def test_sort_values_execution(setup, distinct_opt):
     # test series with None
     series = pd.Series(np.arange(1000))
 
-    series = series.astype('object')
+    series = series.astype("object")
     series[series < 500] = "A"
     series[series != "A"] = None
 

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -169,6 +169,7 @@ def test_sort_values_execution(setup, distinct_opt):
     # test None (issue #1885)
     df = pd.DataFrame(np.random.rand(1000, 10))
 
+    df[0] = df[0].astype('object')
     df[0][df[0] < 0.5] = "A"
     df[0][df[0] != "A"] = None
 
@@ -262,6 +263,7 @@ def test_sort_values_execution(setup, distinct_opt):
     # test series with None
     series = pd.Series(np.arange(1000))
 
+    series = series.astype('object')
     series[series < 500] = "A"
     series[series != "A"] = None
 

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -27,7 +27,6 @@ import subprocess
 import tempfile
 import uuid
 from contextlib import contextmanager
-from distutils.spawn import find_executable
 
 import numpy as np
 
@@ -45,8 +44,8 @@ DOCKER_ROOT = os.path.join((os.path.dirname(os.path.dirname(TEST_ROOT))), "docke
 k8s = lazy_import("kubernetes")
 
 kube_available = (
-    find_executable("kubectl") is not None
-    and find_executable("docker") is not None
+    shutil.which("kubectl") is not None
+    and shutil.which("docker") is not None
     and k8s is not None
 )
 
@@ -55,7 +54,7 @@ def _collect_coverage():
     dist_coverage_path = os.path.join(XORBITS_ROOT, ".dist-coverage")
     if os.path.exists(dist_coverage_path):
         # change ownership of coverage files
-        if find_executable("sudo"):
+        if shutil.which("sudo"):
             proc = subprocess.Popen(
                 [
                     "sudo",

--- a/python/xorbits/deploy/slurm/tests/test_slurm.py
+++ b/python/xorbits/deploy/slurm/tests/test_slurm.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from distutils.spawn import find_executable
+import shutil
 
 import pytest
 
@@ -19,7 +19,7 @@ from .... import init
 from .... import pandas as pd
 from .. import SLURMCluster
 
-slurm_available = find_executable("sbatch") is not None
+slurm_available = shutil.which("sbatch") is not None
 
 
 def test_header_core_process_memory():


### PR DESCRIPTION
- Replace `find_executable` with `shutil.which` to address deprecation.
- Resolve `FutureWarning` by ensuring compatible dtype in Pandas operations.
- Explicitly cast values to match column dtype where necessary.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
