### PR TITLE
ENH: Fix Alluxio version compatibility issue and update to 2.9.5

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    #if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:
@@ -155,7 +155,7 @@ jobs:
           pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[doc]"
         else
           pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
-          pip install -U numpy scipy cython pyftpdlib coverage flaky numexpr openpyxl
+          pip install -U "numpy<2.1,>=1.22" scipy cython pyftpdlib coverage flaky numexpr openpyxl
 
           if [[ "$MODULE" == "mars-core" ]]; then
             pip install oss2
@@ -207,17 +207,17 @@ jobs:
             export CUR_DIR=$(pwd)
             mkdir -p /tmp/alluxio-download-test
             cd /tmp/alluxio-download-test
-            wget -q https://downloads.alluxio.io/downloads/files/2.9.3/alluxio-2.9.3-bin.tar.gz
-            tar -xzf alluxio-2.9.3-bin.tar.gz
-            cd alluxio-2.9.3
+            wget -q https://downloads.alluxio.io/downloads/files/2.9.5/alluxio-2.9.5-bin.tar.gz
+            tar -xzf alluxio-2.9.5-bin.tar.gz
+            cd alluxio-2.9.5
             cp conf/alluxio-env.sh.template conf/alluxio-env.sh
             cp conf/alluxio-site.properties.template conf/alluxio-site.properties
             echo "alluxio.master.hostname=localhost" >> conf/alluxio-site.properties
             cd $CUR_DIR
-            sudo mv /tmp/alluxio-download-test/alluxio-2.9.3 /usr/local/bin/
+            sudo mv /tmp/alluxio-download-test/alluxio-2.9.5 /usr/local/bin/
             rm -R /tmp/alluxio-download-test
             unset CUR_DIR
-            export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.3"
+            export ALLUXIO_HOME="/usr/local/bin/alluxio-2.9.5"
             ${ALLUXIO_HOME}/bin/alluxio format
             ${ALLUXIO_HOME}/bin/alluxio-start.sh local SudoMount
             curl -sSL https://d.juicefs.com/install | sh -

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    #if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -155,7 +155,7 @@ jobs:
           pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[doc]"
         else
           pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
-          pip install -U "numpy<2.1,>=1.22" scipy cython pyftpdlib coverage flaky numexpr openpyxl
+          pip install -U numpy scipy cython pyftpdlib coverage flaky numexpr openpyxl
 
           if [[ "$MODULE" == "mars-core" ]]; then
             pip install oss2


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

This pull request updates the Alluxio version from 2.9.3 to 2.9.5 in the installation script. Fix:

> Successfully installed coverage-7.6.10 cython-3.0.11 et-xmlfile-2.0.0 flaky-3.8.1 numexpr-2.10.2 numpy-2.2.1 openpyxl-3.1.5 pyftpdlib-2.0.1
Error: Alluxio requires Java 8 or Java 11, currently Java 17.0.13 found.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
