### PR TITLE
BLD: upload pypi CI pipeline

### DIFF
--- a/.github/workflows/asv.yaml
+++ b/.github/workflows/asv.yaml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up conda python
-        uses: conda-incubator/setup-miniconda@v3.0.4
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.11
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -162,7 +162,7 @@ jobs:
         env:
           CIBW_ENVIRONMENT_LINUX: NO_WEB_UI=1
           CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
-          CIBW_BUILD: ${{ matrix.python_tag }}-*
+          CIBW_BUILD: cp${{ matrix.python_tag }}*
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python | replace('>=', '') | replace('<', '') | replace(',', '') }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         arch: [auto]
         requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
@@ -88,43 +88,43 @@ jobs:
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.12,<3.13"
             python_tag: cp312

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -26,40 +26,15 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: aarch64
-            requires-python: ">=3.9,<3.10"
-          - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.10,<3.11"
-          - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.11,<3.12"
-          - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.12,<3.13"
           - os: macos-13
             arch: x86_64
-            requires-python: ">=3.9,<3.10"
-          - os: macos-13
-            arch: x86_64
-            requires-python: ">=3.10,<3.11"
-          - os: macos-13
-            arch: x86_64
-            requires-python: ">=3.11,<3.12"
-          - os: macos-13
-            arch: x86_64
-            requires-python: ">=3.12,<3.13"
           - os: macos-13
             arch: universal2
-            requires-python: ">=3.9,<3.10"
+        exclude:
+          - os: macos-latest
+            arch: auto
           - os: macos-13
-            arch: universal2
-            requires-python: ">=3.10,<3.11"
-          - os: macos-13
-            arch: universal2
-            requires-python: ">=3.11,<3.12"
-          - os: macos-13
-            arch: universal2
-            requires-python: ">=3.12,<3.13"
+            arch: auto
 
     steps:
       - uses: actions/checkout@v4
@@ -103,17 +78,9 @@ jobs:
         with:
           package-dir: ./python/
 
-      - name: Set artifact name
-        id: set-name
-        shell: bash
-        run: |
-          version="${{ matrix.requires-python }}"
-          version=$(echo "$version" | sed 's/>=//g' | sed 's/<//g' | sed 's/\.//g')
-          echo "py_version=$version" >> $GITHUB_OUTPUT
-
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ steps.set-name.outputs.py_version }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -12,7 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}
@@ -20,7 +19,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
           # Linux x86_64
           - os: ubuntu-latest
@@ -65,43 +63,43 @@ jobs:
             python: 312
             platform_id: manylinux_aarch64
           # macOS arm64
-          - os: macos-13
+          - os: macos-14
             arch: arm64
             requires-python: ">=3.9,<3.10"
             python: 39
             platform_id: macosx_arm64
-          - os: macos-13
+          - os: macos-14
             arch: arm64
             requires-python: ">=3.10,<3.11"
             python: 310
             platform_id: macosx_arm64
-          - os: macos-13
+          - os: macos-14
             arch: arm64
             requires-python: ">=3.11,<3.12"
             python: 311
             platform_id: macosx_arm64
-          - os: macos-13
+          - os: macos-14
             arch: arm64
             requires-python: ">=3.12,<3.13"
             python: 312
             platform_id: macosx_arm64
           # macOS x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python: 312

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -85,21 +85,15 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_ENVIRONMENT_LINUX: >-
-            NO_WEB_UI=1
-            CFLAGS="-O3"
-            CXXFLAGS="-O3"
-          CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI CFLAGS CXXFLAGS
+          CIBW_ENVIRONMENT_LINUX: NO_WEB_UI=1
+          CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
-          CIBW_BEFORE_ALL_LINUX: yum install -y npm
-          CIBW_BEFORE_BUILD: pip install numpy Cython packaging
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
-          CIBW_BUILD_VERBOSITY: 3
-          CIBW_BUILD: cp*
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64:latest
           DOCKER_BUILDKIT: 1
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -143,11 +143,18 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
+      # Download wheel artifacts
       - uses: actions/download-artifact@v4
         with:
           # Download all wheel artifacts using pattern matching
           pattern: wheel-*
           merge-multiple: true
+          path: wheelhouse
+
+      # Download sdist artifact
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
           path: wheelhouse
 
       # if is xorbits repo, upload to pypi

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -94,8 +94,6 @@ jobs:
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64:latest
-          DOCKER_BUILDKIT: 1
         with:
           package-dir: ./python/
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ replace(replace(replace(matrix.requires-python, '>=', ''), '<', ''), ',', '') }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ format('{0}{1}', matrix.requires-python.split(',')[0] | replace('>=', 'py'), matrix.requires-python.split(',')[1] | replace('<', '_')) }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -143,7 +143,7 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -142,6 +142,10 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write  
+      contents: read   
+
     steps:
       # Download wheel artifacts
       - uses: actions/download-artifact@v4
@@ -149,13 +153,13 @@ jobs:
           # Download all wheel artifacts using pattern matching
           pattern: wheel-*
           merge-multiple: true
-          path: wheelhouse
+          path: dist
 
       # Download sdist artifact
       - uses: actions/download-artifact@v4
         with:
           name: sdist
-          path: wheelhouse
+          path: dist
 
       # if is xorbits repo, upload to pypi
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -163,7 +167,9 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: dist
           skip-existing: true
+          verbose: true
 
       # if is not xorbits repo, upload to test
       - uses: pypa/gh-action-pypi-publish@release/v1
@@ -171,6 +177,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
-          verbose: true
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
           skip-existing: true
+          verbose: true

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.python }}-${{ matrix.platform_id }}
+          name: wheel-${{ matrix.python }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -66,44 +66,65 @@ jobs:
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: manylinux_2_28_aarch64
+          # macOS x86_64 (auto)
+          - os: macos-latest
+            arch: auto
+            requires-python: ">=3.9,<3.10"
+            python_tag: cp39
+            platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: auto
+            requires-python: ">=3.10,<3.11"
+            python_tag: cp310
+            platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: auto
+            requires-python: ">=3.11,<3.12"
+            python_tag: cp311
+            platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: auto
+            requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: macosx_10_9_x86_64
           # macOS x86_64
-          - os: macos-13
+          - os: macos-latest
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-latest
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-latest
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-latest
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS universal2
-          - os: macos-13
+          - os: macos-latest
             arch: universal2
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-latest
             arch: universal2
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-latest
             arch: universal2
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-latest
             arch: universal2
             requires-python: ">=3.12,<3.13"
             python_tag: cp312

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -76,6 +76,14 @@ jobs:
         with:
           platforms: all
 
+      - name: Set up Docker
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.10.5
+        env:
+          DOCKER_BUILDKIT: 0
+
       - name: Build web
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -94,6 +102,8 @@ jobs:
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
           CIBW_BUILD_VERBOSITY: 1
+          DOCKER_BUILDKIT: 0
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
         with:
           package-dir: ./python/
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         arch: [auto]
         requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
@@ -67,64 +67,64 @@ jobs:
             python_tag: cp312
             platform_id: manylinux_2_28_aarch64
           # macOS x86_64 (auto)
-          - os: macos-latest
+          - os: macos-14
             arch: auto
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-14
             arch: auto
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-14
             arch: auto
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-14
             arch: auto
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS x86_64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS universal2
-          - os: macos-13
+          - os: macos-14
             arch: universal2
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-14
             arch: universal2
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-14
             arch: universal2
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_universal2
-          - os: macos-13
+          - os: macos-14
             arch: universal2
             requires-python: ">=3.12,<3.13"
             python_tag: cp312

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -194,7 +194,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python_tag }}
+          name: ${{ matrix.python_tag }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -72,9 +72,9 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
-          platforms: all
+          platforms: arm64
 
       - name: Build web
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -93,8 +93,9 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
-          CIBW_BUILD_VERBOSITY: 3
-          CIBW_BUILD: cp*
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64:latest
+          DOCKER_BUILDKIT: 1
         with:
           package-dir: ./python/
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -85,15 +85,21 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_ENVIRONMENT_LINUX: NO_WEB_UI=1
-          CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
+          CIBW_ENVIRONMENT_LINUX: >-
+            NO_WEB_UI=1
+            CFLAGS="-O3"
+            CXXFLAGS="-O3"
+          CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI CFLAGS CXXFLAGS
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
+          CIBW_BEFORE_ALL_LINUX: yum install -y npm
+          CIBW_BEFORE_BUILD: pip install numpy Cython packaging
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
-          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD: cp*
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64:latest
           DOCKER_BUILDKIT: 1
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.requires-python }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python || 'latest' | replace('>=','') | replace('<','') | replace('.','') }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -20,114 +20,112 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
-        arch: [auto]
         requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
           # Linux x86_64
           - os: ubuntu-latest
             arch: auto
             requires-python: ">=3.9,<3.10"
-            python_tag: cp39
-            platform_id: manylinux_2_28_x86_64
+            python: 39
+            platform_id: manylinux_x86_64
           - os: ubuntu-latest
             arch: auto
             requires-python: ">=3.10,<3.11"
-            python_tag: cp310
-            platform_id: manylinux_2_28_x86_64
+            python: 310
+            platform_id: manylinux_x86_64
           - os: ubuntu-latest
             arch: auto
             requires-python: ">=3.11,<3.12"
-            python_tag: cp311
-            platform_id: manylinux_2_28_x86_64
+            python: 311
+            platform_id: manylinux_x86_64
           - os: ubuntu-latest
             arch: auto
             requires-python: ">=3.12,<3.13"
-            python_tag: cp312
-            platform_id: manylinux_2_28_x86_64
+            python: 312
+            platform_id: manylinux_x86_64
           # Linux aarch64
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.9,<3.10"
-            python_tag: cp39
-            platform_id: manylinux_2_28_aarch64
+            python: 39
+            platform_id: manylinux_aarch64
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.10,<3.11"
-            python_tag: cp310
-            platform_id: manylinux_2_28_aarch64
+            python: 310
+            platform_id: manylinux_aarch64
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.11,<3.12"
-            python_tag: cp311
-            platform_id: manylinux_2_28_aarch64
+            python: 311
+            platform_id: manylinux_aarch64
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.12,<3.13"
-            python_tag: cp312
-            platform_id: manylinux_2_28_aarch64
+            python: 312
+            platform_id: manylinux_aarch64
           # macOS arm64
           - os: macos-13
             arch: arm64
             requires-python: ">=3.9,<3.10"
-            python_tag: cp39
-            platform_id: macosx_11_0_arm64
+            python: 39
+            platform_id: macosx_arm64
           - os: macos-13
             arch: arm64
             requires-python: ">=3.10,<3.11"
-            python_tag: cp310
-            platform_id: macosx_11_0_arm64
+            python: 310
+            platform_id: macosx_arm64
           - os: macos-13
             arch: arm64
             requires-python: ">=3.11,<3.12"
-            python_tag: cp311
-            platform_id: macosx_11_0_arm64
+            python: 311
+            platform_id: macosx_arm64
           - os: macos-13
             arch: arm64
             requires-python: ">=3.12,<3.13"
-            python_tag: cp312
-            platform_id: macosx_11_0_arm64
+            python: 312
+            platform_id: macosx_arm64
           # macOS x86_64
-          - os: macos-13
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.9,<3.10"
-            python_tag: cp39
-            platform_id: macosx_10_9_x86_64
-          - os: macos-13
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.10,<3.11"
-            python_tag: cp310
-            platform_id: macosx_10_9_x86_64
-          - os: macos-13
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.11,<3.12"
-            python_tag: cp311
-            platform_id: macosx_10_9_x86_64
-          - os: macos-13
+            python: 311
+            platform_id: macosx_x86_64
+          - os: macos-14
             arch: x86_64
             requires-python: ">=3.12,<3.13"
-            python_tag: cp312
-            platform_id: macosx_10_9_x86_64
+            python: 312
+            platform_id: macosx_x86_64
           # Windows
           - os: windows-latest
             arch: auto
             requires-python: ">=3.9,<3.10"
-            python_tag: cp39
+            python: 39
             platform_id: win_amd64
           - os: windows-latest
             arch: auto
             requires-python: ">=3.10,<3.11"
-            python_tag: cp310
+            python: 310
             platform_id: win_amd64
           - os: windows-latest
             arch: auto
             requires-python: ">=3.11,<3.12"
-            python_tag: cp311
+            python: 311
             platform_id: win_amd64
           - os: windows-latest
             arch: auto
             requires-python: ">=3.12,<3.13"
-            python_tag: cp312
+            python: 312
             platform_id: win_amd64
 
     steps:
@@ -174,7 +172,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.python_tag }}-${{ matrix.platform_id }}
+          name: ${{ matrix.python }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -20,104 +20,115 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [auto]
+        requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
           # Linux x86_64
-          - python: cp39
-            os: ubuntu-latest
-            platform_id: manylinux_2_28_x86_64
+          - os: ubuntu-latest
+            arch: auto
             requires-python: ">=3.9,<3.10"
-          - python: cp310
-            os: ubuntu-latest
+            python_tag: cp39
             platform_id: manylinux_2_28_x86_64
+          - os: ubuntu-latest
+            arch: auto
             requires-python: ">=3.10,<3.11"
-          - python: cp311
-            os: ubuntu-latest
+            python_tag: cp310
             platform_id: manylinux_2_28_x86_64
+          - os: ubuntu-latest
+            arch: auto
             requires-python: ">=3.11,<3.12"
-          - python: cp312
-            os: ubuntu-latest
+            python_tag: cp311
             platform_id: manylinux_2_28_x86_64
+          - os: ubuntu-latest
+            arch: auto
             requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: manylinux_2_28_x86_64
           # Linux aarch64
-          - python: cp39
-            os: ubuntu-latest
-            platform_id: manylinux_2_28_aarch64
+          - os: ubuntu-latest
+            arch: aarch64
             requires-python: ">=3.9,<3.10"
-            arch: aarch64
-          - python: cp310
-            os: ubuntu-latest
+            python_tag: cp39
             platform_id: manylinux_2_28_aarch64
+          - os: ubuntu-latest
+            arch: aarch64
             requires-python: ">=3.10,<3.11"
-            arch: aarch64
-          - python: cp311
-            os: ubuntu-latest
+            python_tag: cp310
             platform_id: manylinux_2_28_aarch64
+          - os: ubuntu-latest
+            arch: aarch64
             requires-python: ">=3.11,<3.12"
-            arch: aarch64
-          - python: cp312
-            os: ubuntu-latest
+            python_tag: cp311
             platform_id: manylinux_2_28_aarch64
-            requires-python: ">=3.12,<3.13"
+          - os: ubuntu-latest
             arch: aarch64
+            requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: manylinux_2_28_aarch64
           # macOS x86_64
-          - python: cp39
-            os: macos-latest
-            platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: x86_64
             requires-python: ">=3.9,<3.10"
-            arch: x86_64
-          - python: cp310
-            os: macos-latest
+            python_tag: cp39
             platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: x86_64
             requires-python: ">=3.10,<3.11"
-            arch: x86_64
-          - python: cp311
-            os: macos-latest
+            python_tag: cp310
             platform_id: macosx_10_9_x86_64
+          - os: macos-latest
+            arch: x86_64
             requires-python: ">=3.11,<3.12"
-            arch: x86_64
-          - python: cp312
-            os: macos-latest
+            python_tag: cp311
             platform_id: macosx_10_9_x86_64
-            requires-python: ">=3.12,<3.13"
+          - os: macos-latest
             arch: x86_64
+            requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: macosx_10_9_x86_64
           # macOS universal2
-          - python: cp39
-            os: macos-latest
-            platform_id: macosx_10_9_universal2
+          - os: macos-latest
+            arch: universal2
             requires-python: ">=3.9,<3.10"
-            arch: universal2
-          - python: cp310
-            os: macos-latest
+            python_tag: cp39
             platform_id: macosx_10_9_universal2
+          - os: macos-latest
+            arch: universal2
             requires-python: ">=3.10,<3.11"
-            arch: universal2
-          - python: cp311
-            os: macos-latest
+            python_tag: cp310
             platform_id: macosx_10_9_universal2
+          - os: macos-latest
+            arch: universal2
             requires-python: ">=3.11,<3.12"
-            arch: universal2
-          - python: cp312
-            os: macos-latest
+            python_tag: cp311
             platform_id: macosx_10_9_universal2
-            requires-python: ">=3.12,<3.13"
+          - os: macos-latest
             arch: universal2
+            requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: macosx_10_9_universal2
           # Windows
-          - python: cp39
-            os: windows-latest
-            platform_id: win_amd64
+          - os: windows-latest
+            arch: auto
             requires-python: ">=3.9,<3.10"
-          - python: cp310
-            os: windows-latest
+            python_tag: cp39
             platform_id: win_amd64
+          - os: windows-latest
+            arch: auto
             requires-python: ">=3.10,<3.11"
-          - python: cp311
-            os: windows-latest
+            python_tag: cp310
             platform_id: win_amd64
+          - os: windows-latest
+            arch: auto
             requires-python: ">=3.11,<3.12"
-          - python: cp312
-            os: windows-latest
+            python_tag: cp311
             platform_id: win_amd64
+          - os: windows-latest
+            arch: auto
             requires-python: ">=3.12,<3.13"
+            python_tag: cp312
+            platform_id: win_amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -160,6 +171,36 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
         with:
           package-dir: ./python/
+
+      - name: Get Python tag
+        id: get_tag
+        shell: bash
+        run: |
+          if [[ "${{ matrix.requires-python }}" == ">=3.9,<3.10" ]]; then
+            echo "python_tag=cp39" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.requires-python }}" == ">=3.10,<3.11" ]]; then
+            echo "python_tag=cp310" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.requires-python }}" == ">=3.11,<3.12" ]]; then
+            echo "python_tag=cp311" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.requires-python }}" == ">=3.12,<3.13" ]]; then
+            echo "python_tag=cp312" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get platform id
+        id: get_platform
+        shell: bash
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.arch }}" == "auto" ]]; then
+            echo "platform_id=manylinux_2_28_x86_64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.arch }}" == "aarch64" ]]; then
+            echo "platform_id=manylinux_2_28_aarch64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "x86_64" ]]; then
+            echo "platform_id=macosx_10_9_x86_64" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "universal2" ]]; then
+            echo "platform_id=macosx_10_9_universal2" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            echo "platform_id=win_amd64" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -26,15 +26,40 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: aarch64
+            requires-python: ">=3.9,<3.10"
+          - os: ubuntu-latest
+            arch: aarch64
+            requires-python: ">=3.10,<3.11"
+          - os: ubuntu-latest
+            arch: aarch64
+            requires-python: ">=3.11,<3.12"
+          - os: ubuntu-latest
+            arch: aarch64
+            requires-python: ">=3.12,<3.13"
           - os: macos-13
             arch: x86_64
+            requires-python: ">=3.9,<3.10"
+          - os: macos-13
+            arch: x86_64
+            requires-python: ">=3.10,<3.11"
+          - os: macos-13
+            arch: x86_64
+            requires-python: ">=3.11,<3.12"
+          - os: macos-13
+            arch: x86_64
+            requires-python: ">=3.12,<3.13"
           - os: macos-13
             arch: universal2
-        exclude:
-          - os: macos-latest
-            arch: auto
+            requires-python: ">=3.9,<3.10"
           - os: macos-13
-            arch: auto
+            arch: universal2
+            requires-python: ">=3.10,<3.11"
+          - os: macos-13
+            arch: universal2
+            requires-python: ">=3.11,<3.12"
+          - os: macos-13
+            arch: universal2
+            requires-python: ">=3.12,<3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -20,134 +20,103 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        arch: [auto]
         include:
           # Linux x86_64
-          - os: ubuntu-latest
-            python: "3.9"
-            arch: auto
+          - python: cp39
+            os: ubuntu-latest
             platform_id: manylinux_2_28_x86_64
-            python_tag: cp39
             requires-python: ">=3.9,<3.10"
-          - os: ubuntu-latest
-            python: "3.10"
-            arch: auto
+          - python: cp310
+            os: ubuntu-latest
             platform_id: manylinux_2_28_x86_64
-            python_tag: cp310
             requires-python: ">=3.10,<3.11"
-          - os: ubuntu-latest
-            python: "3.11"
-            arch: auto
+          - python: cp311
+            os: ubuntu-latest
             platform_id: manylinux_2_28_x86_64
-            python_tag: cp311
             requires-python: ">=3.11,<3.12"
-          - os: ubuntu-latest
-            python: "3.12"
-            arch: auto
+          - python: cp312
+            os: ubuntu-latest
             platform_id: manylinux_2_28_x86_64
-            python_tag: cp312
             requires-python: ">=3.12,<3.13"
           # Linux aarch64
-          - os: ubuntu-latest
-            python: "3.9"
-            arch: aarch64
+          - python: cp39
+            os: ubuntu-latest
             platform_id: manylinux_2_28_aarch64
-            python_tag: cp39
             requires-python: ">=3.9,<3.10"
-          - os: ubuntu-latest
-            python: "3.10"
             arch: aarch64
+          - python: cp310
+            os: ubuntu-latest
             platform_id: manylinux_2_28_aarch64
-            python_tag: cp310
             requires-python: ">=3.10,<3.11"
-          - os: ubuntu-latest
-            python: "3.11"
             arch: aarch64
+          - python: cp311
+            os: ubuntu-latest
             platform_id: manylinux_2_28_aarch64
-            python_tag: cp311
             requires-python: ">=3.11,<3.12"
-          - os: ubuntu-latest
-            python: "3.12"
             arch: aarch64
+          - python: cp312
+            os: ubuntu-latest
             platform_id: manylinux_2_28_aarch64
-            python_tag: cp312
             requires-python: ">=3.12,<3.13"
+            arch: aarch64
           # macOS x86_64
-          - os: macos-13
-            python: "3.9"
-            arch: x86_64
+          - python: cp39
+            os: macos-latest
             platform_id: macosx_10_9_x86_64
-            python_tag: cp39
             requires-python: ">=3.9,<3.10"
-          - os: macos-13
-            python: "3.10"
             arch: x86_64
+          - python: cp310
+            os: macos-latest
             platform_id: macosx_10_9_x86_64
-            python_tag: cp310
             requires-python: ">=3.10,<3.11"
-          - os: macos-13
-            python: "3.11"
             arch: x86_64
+          - python: cp311
+            os: macos-latest
             platform_id: macosx_10_9_x86_64
-            python_tag: cp311
             requires-python: ">=3.11,<3.12"
-          - os: macos-13
-            python: "3.12"
             arch: x86_64
+          - python: cp312
+            os: macos-latest
             platform_id: macosx_10_9_x86_64
-            python_tag: cp312
             requires-python: ">=3.12,<3.13"
+            arch: x86_64
           # macOS universal2
-          - os: macos-13
-            python: "3.9"
-            arch: universal2
+          - python: cp39
+            os: macos-latest
             platform_id: macosx_10_9_universal2
-            python_tag: cp39
             requires-python: ">=3.9,<3.10"
-          - os: macos-13
-            python: "3.10"
             arch: universal2
+          - python: cp310
+            os: macos-latest
             platform_id: macosx_10_9_universal2
-            python_tag: cp310
             requires-python: ">=3.10,<3.11"
-          - os: macos-13
-            python: "3.11"
             arch: universal2
+          - python: cp311
+            os: macos-latest
             platform_id: macosx_10_9_universal2
-            python_tag: cp311
             requires-python: ">=3.11,<3.12"
-          - os: macos-13
-            python: "3.12"
             arch: universal2
+          - python: cp312
+            os: macos-latest
             platform_id: macosx_10_9_universal2
-            python_tag: cp312
             requires-python: ">=3.12,<3.13"
+            arch: universal2
           # Windows
-          - os: windows-latest
-            python: "3.9"
-            arch: auto
+          - python: cp39
+            os: windows-latest
             platform_id: win_amd64
-            python_tag: cp39
             requires-python: ">=3.9,<3.10"
-          - os: windows-latest
-            python: "3.10"
-            arch: auto
+          - python: cp310
+            os: windows-latest
             platform_id: win_amd64
-            python_tag: cp310
             requires-python: ">=3.10,<3.11"
-          - os: windows-latest
-            python: "3.11"
-            arch: auto
+          - python: cp311
+            os: windows-latest
             platform_id: win_amd64
-            python_tag: cp311
             requires-python: ">=3.11,<3.12"
-          - os: windows-latest
-            python: "3.12"
-            arch: auto
+          - python: cp312
+            os: windows-latest
             platform_id: win_amd64
-            python_tag: cp312
             requires-python: ">=3.12,<3.13"
 
     steps:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -151,7 +151,6 @@ jobs:
       # Download wheel artifacts
       - uses: actions/download-artifact@v4
         with:
-          # Download all wheel artifacts using pattern matching
           pattern: wheel-*
           merge-multiple: true
           path: dist
@@ -163,17 +162,22 @@ jobs:
           path: dist
 
       # if is xorbits repo, upload to pypi
-      - name: Publish 🐍📦 to PyPI
+      - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.repository == 'xorbitsai/xorbits'
-        uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: dist
+          skip-existing: true
           verbose: true
 
       # if is not xorbits repo, upload to test
-      - name: Publish 🐍📦 to Test PyPI
+      - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.repository != 'xorbitsai/xorbits'
-        uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_PASSWORD }}
           repository-url: https://test.pypi.org/legacy/
-          package-name: xorbits-test
+          packages-dir: dist
+          skip-existing: true
           verbose: true

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -93,7 +93,8 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
-          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD: cp*
         with:
           package-dir: ./python/
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -163,22 +163,17 @@ jobs:
           path: dist
 
       # if is xorbits repo, upload to pypi
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish 🐍📦 to PyPI
         if: github.repository == 'xorbitsai/xorbits'
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
-          packages-dir: dist
-          skip-existing: true
           verbose: true
 
       # if is not xorbits repo, upload to test
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish 🐍📦 to Test PyPI
         if: github.repository != 'xorbitsai/xorbits'
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_PASSWORD }}
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist
-          skip-existing: true
+          package-name: xorbits-test
           verbose: true

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ format('{0}{1}', matrix.requires-python.split(',')[0] | replace('>=', 'py'), matrix.requires-python.split(',')[1] | replace('<', '_')) }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ format('{0}{1}', contains(matrix.requires-python, '3.9') && '39' || contains(matrix.requires-python, '3.10') && '310' || contains(matrix.requires-python, '3.11') && '311' || contains(matrix.requires-python, '3.12') && '312') }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -145,10 +145,10 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
+          # Download all wheel artifacts using pattern matching
+          pattern: wheel-*
+          merge-multiple: true
+          path: wheelhouse
 
       # if is xorbits repo, upload to pypi
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -72,9 +72,14 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+          # This should be temporary
+          # xref https://github.com/docker/setup-qemu-action/issues/188
+          # xref https://github.com/tonistiigi/binfmt/issues/215
+          image: tonistiigi/binfmt:qemu-v8.1.5
+          id: qemu
 
       - name: Build web
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -68,13 +68,13 @@ jobs:
 
       - name: Add msbuild to PATH
         if: ${{ matrix.os == 'windows-latest'}}
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v1.1
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: all
 
       - name: Build web
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -97,9 +97,16 @@ jobs:
         with:
           package-dir: ./python/
 
+      - name: Set artifact name
+        id: set-name
+        run: |
+          version="${{ matrix.requires-python }}"
+          version=$(echo "$version" | sed 's/>=//g' | sed 's/<//g' | sed 's/\.//g')
+          echo "py_version=$version" >> $GITHUB_OUTPUT
+
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python || 'latest' | replace('>=','') | replace('<','') | replace('.','') }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ steps.set-name.outputs.py_version }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Set artifact name
         id: set-name
+        shell: bash
         run: |
           version="${{ matrix.requires-python }}"
           version=$(echo "$version" | sed 's/>=//g' | sed 's/<//g' | sed 's/\.//g')

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -142,10 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      id-token: write  
-      contents: read   
-
     steps:
       # Download wheel artifacts
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -76,14 +76,6 @@ jobs:
         with:
           platforms: all
 
-      - name: Set up Docker
-        if: ${{ matrix.arch == 'aarch64' }}
-        uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.10.5
-        env:
-          DOCKER_BUILDKIT: 0
-
       - name: Build web
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -102,8 +94,6 @@ jobs:
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
           CIBW_TEST_REQUIRES: pytest requests
           CIBW_BUILD_VERBOSITY: 1
-          DOCKER_BUILDKIT: 0
-          DOCKER_DEFAULT_PLATFORM: linux/amd64
         with:
           package-dir: ./python/
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -164,10 +164,7 @@ jobs:
           CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
           CIBW_BUILD: ${{ matrix.python_tag }}-*
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_PROJECT_REQUIRES_PYTHON: >-
-            ${{ format('>={0},<{1}', matrix.python,
-            startsWith(matrix.python, '3.') && format('3.{0}', add(parseFloat(substring(matrix.python, 2)), 1))
-            ) }}
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -12,6 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}
@@ -142,6 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write
+      contents: write
+
     steps:
       # Download wheel artifacts
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -21,45 +21,114 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         arch: [auto]
-        requires-python: [">=3.9,<3.10", ">=3.10,<3.11", ">=3.11,<3.12", ">=3.12,<3.13"]
         include:
+          # Linux x86_64
           - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.9,<3.10"
+            python: "3.9"
+            arch: auto
+            platform_id: manylinux_2_28_x86_64
+            python_tag: cp39
           - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.10,<3.11"
+            python: "3.10"
+            arch: auto
+            platform_id: manylinux_2_28_x86_64
+            python_tag: cp310
           - os: ubuntu-latest
-            arch: aarch64
-            requires-python: ">=3.11,<3.12"
+            python: "3.11"
+            arch: auto
+            platform_id: manylinux_2_28_x86_64
+            python_tag: cp311
           - os: ubuntu-latest
+            python: "3.12"
+            arch: auto
+            platform_id: manylinux_2_28_x86_64
+            python_tag: cp312
+          # Linux aarch64
+          - os: ubuntu-latest
+            python: "3.9"
             arch: aarch64
-            requires-python: ">=3.12,<3.13"
+            platform_id: manylinux_2_28_aarch64
+            python_tag: cp39
+          - os: ubuntu-latest
+            python: "3.10"
+            arch: aarch64
+            platform_id: manylinux_2_28_aarch64
+            python_tag: cp310
+          - os: ubuntu-latest
+            python: "3.11"
+            arch: aarch64
+            platform_id: manylinux_2_28_aarch64
+            python_tag: cp311
+          - os: ubuntu-latest
+            python: "3.12"
+            arch: aarch64
+            platform_id: manylinux_2_28_aarch64
+            python_tag: cp312
+          # macOS x86_64
           - os: macos-13
+            python: "3.9"
             arch: x86_64
-            requires-python: ">=3.9,<3.10"
+            platform_id: macosx_10_9_x86_64
+            python_tag: cp39
           - os: macos-13
+            python: "3.10"
             arch: x86_64
-            requires-python: ">=3.10,<3.11"
+            platform_id: macosx_10_9_x86_64
+            python_tag: cp310
           - os: macos-13
+            python: "3.11"
             arch: x86_64
-            requires-python: ">=3.11,<3.12"
+            platform_id: macosx_10_9_x86_64
+            python_tag: cp311
           - os: macos-13
+            python: "3.12"
             arch: x86_64
-            requires-python: ">=3.12,<3.13"
+            platform_id: macosx_10_9_x86_64
+            python_tag: cp312
+          # macOS universal2
           - os: macos-13
+            python: "3.9"
             arch: universal2
-            requires-python: ">=3.9,<3.10"
+            platform_id: macosx_10_9_universal2
+            python_tag: cp39
           - os: macos-13
+            python: "3.10"
             arch: universal2
-            requires-python: ">=3.10,<3.11"
+            platform_id: macosx_10_9_universal2
+            python_tag: cp310
           - os: macos-13
+            python: "3.11"
             arch: universal2
-            requires-python: ">=3.11,<3.12"
+            platform_id: macosx_10_9_universal2
+            python_tag: cp311
           - os: macos-13
+            python: "3.12"
             arch: universal2
-            requires-python: ">=3.12,<3.13"
+            platform_id: macosx_10_9_universal2
+            python_tag: cp312
+          # Windows
+          - os: windows-latest
+            python: "3.9"
+            arch: auto
+            platform_id: win_amd64
+            python_tag: cp39
+          - os: windows-latest
+            python: "3.10"
+            arch: auto
+            platform_id: win_amd64
+            python_tag: cp310
+          - os: windows-latest
+            python: "3.11"
+            arch: auto
+            platform_id: win_amd64
+            python_tag: cp311
+          - os: windows-latest
+            python: "3.12"
+            arch: auto
+            platform_id: win_amd64
+            python_tag: cp312
 
     steps:
       - uses: actions/checkout@v4
@@ -93,8 +162,12 @@ jobs:
         env:
           CIBW_ENVIRONMENT_LINUX: NO_WEB_UI=1
           CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
+          CIBW_BUILD: ${{ matrix.python_tag }}-*
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
+          CIBW_PROJECT_REQUIRES_PYTHON: >-
+            ${{ format('>={0},<{1}', matrix.python,
+            startsWith(matrix.python, '3.') && format('3.{0}', add(parseFloat(substring(matrix.python, 2)), 1))
+            ) }}
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py
@@ -105,7 +178,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ format('{0}{1}', contains(matrix.requires-python, '3.9') && '39' || contains(matrix.requires-python, '3.10') && '310' || contains(matrix.requires-python, '3.11') && '311' || contains(matrix.requires-python, '3.12') && '312') }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.python_tag }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -67,68 +67,47 @@ jobs:
             python_tag: cp312
             platform_id: manylinux_2_28_aarch64
           # macOS x86_64 (auto)
-          - os: macos-14
+          - os: macos-13
             arch: auto
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: auto
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: auto
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: auto
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-14
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
-          # macOS universal2
-          - os: macos-14
-            arch: universal2
-            requires-python: ">=3.9,<3.10"
-            python_tag: cp39
-            platform_id: macosx_10_9_universal2
-          - os: macos-14
-            arch: universal2
-            requires-python: ">=3.10,<3.11"
-            python_tag: cp310
-            platform_id: macosx_10_9_universal2
-          - os: macos-14
-            arch: universal2
-            requires-python: ">=3.11,<3.12"
-            python_tag: cp311
-            platform_id: macosx_10_9_universal2
-          - os: macos-14
-            arch: universal2
-            requires-python: ">=3.12,<3.13"
-            python_tag: cp312
-            platform_id: macosx_10_9_universal2
           # Windows
           - os: windows-latest
             arch: auto

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -66,27 +66,27 @@ jobs:
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: manylinux_2_28_aarch64
-          # macOS x86_64 (auto)
+          # macOS arm64
           - os: macos-13
-            arch: auto
+            arch: arm64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
-            platform_id: macosx_10_9_x86_64
+            platform_id: macosx_11_0_arm64
           - os: macos-13
-            arch: auto
+            arch: arm64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
-            platform_id: macosx_10_9_x86_64
+            platform_id: macosx_11_0_arm64
           - os: macos-13
-            arch: auto
+            arch: arm64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
-            platform_id: macosx_10_9_x86_64
+            platform_id: macosx_11_0_arm64
           - os: macos-13
-            arch: auto
+            arch: arm64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
-            platform_id: macosx_10_9_x86_64
+            platform_id: macosx_11_0_arm64
           # macOS x86_64
           - os: macos-13
             arch: x86_64

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -61,14 +61,14 @@ jobs:
             requires-python: ">=3.12,<3.13"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Add msbuild to PATH
         if: ${{ matrix.os == 'windows-latest'}}
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
@@ -97,7 +97,7 @@ jobs:
         with:
           package-dir: ./python/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
 
@@ -105,7 +105,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -118,7 +118,7 @@ jobs:
       - name: Build sdist
         run: cd python && pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./python/dist/*.tar.gz
 

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -99,6 +99,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.requires-python }}
           path: wheelhouse/*.whl
 
   build_sdist:
@@ -120,6 +121,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: ./python/dist/*.tar.gz
 
   upload_pypi:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.requires-python | replace('>=', '') | replace('<', '') | replace(',', '') }}
+          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-py${{ replace(replace(replace(matrix.requires-python, '>=', ''), '<', ''), ',', '') }}
           path: wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -30,105 +30,125 @@ jobs:
             arch: auto
             platform_id: manylinux_2_28_x86_64
             python_tag: cp39
+            requires-python: ">=3.9,<3.10"
           - os: ubuntu-latest
             python: "3.10"
             arch: auto
             platform_id: manylinux_2_28_x86_64
             python_tag: cp310
+            requires-python: ">=3.10,<3.11"
           - os: ubuntu-latest
             python: "3.11"
             arch: auto
             platform_id: manylinux_2_28_x86_64
             python_tag: cp311
+            requires-python: ">=3.11,<3.12"
           - os: ubuntu-latest
             python: "3.12"
             arch: auto
             platform_id: manylinux_2_28_x86_64
             python_tag: cp312
+            requires-python: ">=3.12,<3.13"
           # Linux aarch64
           - os: ubuntu-latest
             python: "3.9"
             arch: aarch64
             platform_id: manylinux_2_28_aarch64
             python_tag: cp39
+            requires-python: ">=3.9,<3.10"
           - os: ubuntu-latest
             python: "3.10"
             arch: aarch64
             platform_id: manylinux_2_28_aarch64
             python_tag: cp310
+            requires-python: ">=3.10,<3.11"
           - os: ubuntu-latest
             python: "3.11"
             arch: aarch64
             platform_id: manylinux_2_28_aarch64
             python_tag: cp311
+            requires-python: ">=3.11,<3.12"
           - os: ubuntu-latest
             python: "3.12"
             arch: aarch64
             platform_id: manylinux_2_28_aarch64
             python_tag: cp312
+            requires-python: ">=3.12,<3.13"
           # macOS x86_64
           - os: macos-13
             python: "3.9"
             arch: x86_64
             platform_id: macosx_10_9_x86_64
             python_tag: cp39
+            requires-python: ">=3.9,<3.10"
           - os: macos-13
             python: "3.10"
             arch: x86_64
             platform_id: macosx_10_9_x86_64
             python_tag: cp310
+            requires-python: ">=3.10,<3.11"
           - os: macos-13
             python: "3.11"
             arch: x86_64
             platform_id: macosx_10_9_x86_64
             python_tag: cp311
+            requires-python: ">=3.11,<3.12"
           - os: macos-13
             python: "3.12"
             arch: x86_64
             platform_id: macosx_10_9_x86_64
             python_tag: cp312
+            requires-python: ">=3.12,<3.13"
           # macOS universal2
           - os: macos-13
             python: "3.9"
             arch: universal2
             platform_id: macosx_10_9_universal2
             python_tag: cp39
+            requires-python: ">=3.9,<3.10"
           - os: macos-13
             python: "3.10"
             arch: universal2
             platform_id: macosx_10_9_universal2
             python_tag: cp310
+            requires-python: ">=3.10,<3.11"
           - os: macos-13
             python: "3.11"
             arch: universal2
             platform_id: macosx_10_9_universal2
             python_tag: cp311
+            requires-python: ">=3.11,<3.12"
           - os: macos-13
             python: "3.12"
             arch: universal2
             platform_id: macosx_10_9_universal2
             python_tag: cp312
+            requires-python: ">=3.12,<3.13"
           # Windows
           - os: windows-latest
             python: "3.9"
             arch: auto
             platform_id: win_amd64
             python_tag: cp39
+            requires-python: ">=3.9,<3.10"
           - os: windows-latest
             python: "3.10"
             arch: auto
             platform_id: win_amd64
             python_tag: cp310
+            requires-python: ">=3.10,<3.11"
           - os: windows-latest
             python: "3.11"
             arch: auto
             platform_id: win_amd64
             python_tag: cp311
+            requires-python: ">=3.11,<3.12"
           - os: windows-latest
             python: "3.12"
             arch: auto
             platform_id: win_amd64
             python_tag: cp312
+            requires-python: ">=3.12,<3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -162,9 +182,8 @@ jobs:
         env:
           CIBW_ENVIRONMENT_LINUX: NO_WEB_UI=1
           CIBW_ENVIRONMENT_PASS_LINUX: NO_WEB_UI
-          CIBW_BUILD: cp${{ matrix.python_tag }}*
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_BEFORE_BUILD_MACOS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_BEFORE_BUILD_WINDOWS: pip install -r CI/requirements-wheel.txt && cd python && python setup.py build_web && git reset --hard HEAD
           CIBW_TEST_COMMAND: pytest {project}/CI/test_basic_execution.py

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -67,43 +67,43 @@ jobs:
             python_tag: cp312
             platform_id: manylinux_2_28_aarch64
           # macOS x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_x86_64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
             platform_id: macosx_10_9_x86_64
           # macOS universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.9,<3.10"
             python_tag: cp39
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.10,<3.11"
             python_tag: cp310
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.11,<3.12"
             python_tag: cp311
             platform_id: macosx_10_9_universal2
-          - os: macos-latest
+          - os: macos-13
             arch: universal2
             requires-python: ">=3.12,<3.13"
             python_tag: cp312
@@ -171,36 +171,6 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
         with:
           package-dir: ./python/
-
-      - name: Get Python tag
-        id: get_tag
-        shell: bash
-        run: |
-          if [[ "${{ matrix.requires-python }}" == ">=3.9,<3.10" ]]; then
-            echo "python_tag=cp39" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.requires-python }}" == ">=3.10,<3.11" ]]; then
-            echo "python_tag=cp310" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.requires-python }}" == ">=3.11,<3.12" ]]; then
-            echo "python_tag=cp311" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.requires-python }}" == ">=3.12,<3.13" ]]; then
-            echo "python_tag=cp312" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Get platform id
-        id: get_platform
-        shell: bash
-        run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.arch }}" == "auto" ]]; then
-            echo "platform_id=manylinux_2_28_x86_64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.arch }}" == "aarch64" ]]; then
-            echo "platform_id=manylinux_2_28_aarch64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "x86_64" ]]; then
-            echo "platform_id=macosx_10_9_x86_64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "universal2" ]]; then
-            echo "platform_id=macosx_10_9_universal2" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            echo "platform_id=win_amd64" >> $GITHUB_OUTPUT
-          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -21,13 +21,13 @@ jobs:
         cuda-version: [ "none", "12.0", "12.5" ]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,6 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,6 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - '*'
-    tags:
-      - 'v*'
-      - 'test-*'
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
 
@@ -414,24 +411,6 @@ jobs:
           --ignore xorbits/sklearn --ignore xorbits/_mars/learn \
           --cov-config=setup.cfg --cov-report=xml --cov=xorbits \
           xorbits
-      working-directory: ./python
-
-    - name: Build and Publish
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        IS_TEST: ${{ contains(github.ref, 'test-') }}
-      run: |
-        pip install build twine
-        python -m build
-        if [[ "$IS_TEST" == "true" ]]; then
-          python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* \
-            --username __token__ \
-            --password ${{ secrets.TEST_PYPI_TOKEN }}
-        else
-          python -m twine upload dist/* \
-            --username __token__ \
-            --password ${{ secrets.PYPI_TOKEN }}
-        fi
       working-directory: ./python
 
     - name: Cleanup on slurm

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '*'
+    tags:
+      - 'v*'
+      - 'test-*'
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
 
@@ -22,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: flake8 Lint
@@ -103,7 +106,7 @@ jobs:
           # - { os: ubuntu-latest, module: compatibility, python-version: 3.9 }
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -419,7 +419,8 @@ jobs:
 
     - name: Build and Publish
       if: startsWith(github.ref, 'refs/tags/')
-      environment: pypi-publish
+      env:
+        IS_TEST: ${{ contains(github.ref, 'test-') }}
       run: |
         pip install build twine
         python -m build
@@ -432,8 +433,6 @@ jobs:
             --username __token__ \
             --password ${{ secrets.PYPI_TOKEN }}
         fi
-      env:
-        IS_TEST: ${{ contains(github.ref, 'test-') }}
       working-directory: ./python
 
     - name: Cleanup on slurm

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -414,6 +414,24 @@ jobs:
           xorbits
       working-directory: ./python
 
+    - name: Build and Publish
+      if: startsWith(github.ref, 'refs/tags/')
+      environment: pypi-publish
+      run: |
+        pip install build twine
+        python -m build
+        if [[ "$IS_TEST" == "true" ]]; then
+          python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* \
+            --username __token__ \
+            --password ${{ secrets.TEST_PYPI_TOKEN }}
+        else
+          python -m twine upload dist/* \
+            --username __token__ \
+            --password ${{ secrets.PYPI_TOKEN }}
+        fi
+      env:
+        IS_TEST: ${{ contains(github.ref, 'test-') }}
+      working-directory: ./python
 
     - name: Cleanup on slurm
       if: ${{ matrix.module == 'slurm' }}

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -15,6 +15,7 @@ classifier =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -224,6 +224,7 @@ def build_long_description():
 
 
 setup_options = dict(
+    name="xorbits-test",  # 临时修改用于测试，原为 "xorbits"
     version=versioneer.get_version(),
     ext_modules=extensions,
     cmdclass=versioneer.get_cmdclass(

--- a/python/setup.py
+++ b/python/setup.py
@@ -224,7 +224,6 @@ def build_long_description():
 
 
 setup_options = dict(
-    name="xorbits-test",  # 临时修改用于测试，原为 "xorbits"
     version=versioneer.get_version(),
     ext_modules=extensions,
     cmdclass=versioneer.get_cmdclass(


### PR DESCRIPTION
## What do these changes do?

This PR optimizes the GitHub Actions workflow for building wheels by:

1. Using the latest versions of GitHub Actions:
- Updated actions/checkout to v4
- Updated actions/upload-artifact to v4
- Updated actions/download-artifact to v4
- Updated pypa/cibuildwheel to v2.16.5
2. Improving the TestPyPI configuration:
- Added conditional logic to determine the target PyPI repository based on the repository name
- When building from a fork (not xorbitsai/xorbits), packages are uploaded to TestPyPI
- When building from the main repository, packages are uploaded to the official PyPI

These changes make the workflow more maintainable and consistent with [scikit-learn's](https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/wheels.yml) approach.

## Related issue number

Fixes #845

## Check code requirements

- [x] tests added / passed (workflow changes only, no code changes)
- [x] Ensure all linting tests pass