### PR TITLE
ENH: Fix deprecation warnings about `__array__` and `quantile`

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xorbits'
+    if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         run: cd python/xorbits/web/ui && ./node_modules/.bin/prettier --check .
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xorbits'
+    # if: github.repository == 'xorbitsai/xorbits'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:
@@ -156,7 +156,7 @@ jobs:
         else
           pip install -e "git+https://github.com/xorbitsai/xoscar.git@main#subdirectory=python&egg=xoscar"
           # TODO: pandas v2.2.3 now does not support well for numpy v2.2.0 and pyarrow v19.0.0. 
-          pip install -U "numpy<2.2.0" "pyarrow<19.0.0" scipy cython pyftpdlib coverage flaky numexpr openpyxl
+          pip install -U numpy pyarrow scipy cython pyftpdlib coverage flaky numexpr openpyxl
 
           if [[ "$MODULE" == "mars-core" ]]; then
             pip install oss2
@@ -291,7 +291,7 @@ jobs:
       run: |
         source activate ${{ env.CONDA_ENV }}
         pip install --extra-index-url=https://pypi.nvidia.com cudf-cu12==24.10.*
-        pip install ucxx-cu12 cython "numpy>=1.14.0,<2.0.0" cloudpickle scikit-learn \
+        pip install ucxx-cu12 cython numpy cloudpickle scikit-learn \
           pyyaml psutil tornado sqlalchemy defusedxml tqdm uvloop coverage \
           pytest pytest-cov pytest-timeout pytest-forked pytest-asyncio pytest-mock
         pip install -U xoscar

--- a/python/xorbits/_mars/dataframe/core.py
+++ b/python/xorbits/_mars/dataframe/core.py
@@ -954,15 +954,15 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
     def __repr__(self):
         return self._to_str(representation=True)
 
-    def _to_arr(self):
+    def _to_arr(self, dtype=None, copy=None):
         if len(self._executed_sessions) == 0:  # pragma: no cover
             raise NotImplementedError
 
         data = self.fetch(session=self._executed_sessions[-1])
-        return np.asarray(data)
+        return np.asarray(data, dtype=dtype, copy=copy)
 
-    def __array__(self):
-        return self._to_arr()
+    def __array__(self, dtype=None, copy=None):
+        return self._to_arr(dtype, copy)
 
     def _to_mars_tensor(self, dtype=None, order="K", extract_multi_index=False):
         tensor = self.to_tensor(extract_multi_index=extract_multi_index)
@@ -1455,15 +1455,15 @@ class BaseSeriesData(HasShapeTileableData, _ToPandasMixin):
     def __repr__(self):
         return self._to_str(representation=False)
 
-    def _to_arr(self):
+    def _to_arr(self, dtype=None, copy=None):
         if len(self._executed_sessions) == 0:  # pragma: no cover
             raise NotImplementedError
 
         data = self.fetch(session=self._executed_sessions[-1])
-        return np.asarray(data)
+        return np.asarray(data, dtype=dtype, copy=copy)
 
-    def __array__(self):
-        return self._to_arr()
+    def __array__(self, dtype=None, copy=None):
+        return self._to_arr(dtype=dtype, copy=copy)
 
     @property
     def dtype(self):
@@ -2054,9 +2054,9 @@ class BaseDataFrameData(HasShapeTileableData, _ToPandasMixin):
         "chunks",
         FieldTypes.reference(DataFrameChunkData),
         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
-        on_deserialize=lambda x: [DataFrameChunk(it) for it in x]
-        if x is not None
-        else x,
+        on_deserialize=lambda x: (
+            [DataFrameChunk(it) for it in x] if x is not None else x
+        ),
     )
 
     def __init__(
@@ -2263,15 +2263,15 @@ class DataFrameData(_BatchedFetcher, BaseDataFrameData):
     def __str__(self):
         return self._to_str(representation=False)
 
-    def _to_arr(self):
+    def _to_arr(self, dtype=None, copy=None):
         if len(self._executed_sessions) == 0:
             raise NotImplementedError
 
         data = self.fetch(session=self._executed_sessions[-1])
-        return np.asarray(data)
+        return np.asarray(data, dtype=dtype, copy=copy)
 
-    def __array__(self):
-        return self._to_arr()
+    def __array__(self, dtype=None, copy=None):
+        return self._to_arr(dtype=dtype, copy=copy)
 
     def __repr__(self):
         return self._to_str(representation=True)
@@ -2767,9 +2767,9 @@ class DataFrameGroupByData(BaseDataFrameData):
         "chunks",
         FieldTypes.reference(DataFrameGroupByChunkData),
         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
-        on_deserialize=lambda x: [DataFrameGroupByChunk(it) for it in x]
-        if x is not None
-        else x,
+        on_deserialize=lambda x: (
+            [DataFrameGroupByChunk(it) for it in x] if x is not None else x
+        ),
     )
 
     @property
@@ -2816,9 +2816,9 @@ class SeriesGroupByData(BaseSeriesData):
         "chunks",
         FieldTypes.reference(SeriesGroupByChunkData),
         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
-        on_deserialize=lambda x: [SeriesGroupByChunk(it) for it in x]
-        if x is not None
-        else x,
+        on_deserialize=lambda x: (
+            [SeriesGroupByChunk(it) for it in x] if x is not None else x
+        ),
     )
 
     @property
@@ -2995,9 +2995,9 @@ class CategoricalData(HasShapeTileableData, _ToPandasMixin):
         "chunks",
         FieldTypes.reference(CategoricalChunkData),
         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
-        on_deserialize=lambda x: [CategoricalChunk(it) for it in x]
-        if x is not None
-        else x,
+        on_deserialize=lambda x: (
+            [CategoricalChunk(it) for it in x] if x is not None else x
+        ),
     )
 
     def __init__(
@@ -3195,9 +3195,9 @@ class DataFrameOrSeriesData(HasShapeTileableData, _ToPandasMixin):
         "chunks",
         FieldTypes.reference(DataFrameOrSeriesChunkData),
         on_serialize=lambda x: [it.data for it in x] if x is not None else x,
-        on_deserialize=lambda x: [DataFrameOrSeriesChunk(it) for it in x]
-        if x is not None
-        else x,
+        on_deserialize=lambda x: (
+            [DataFrameOrSeriesChunk(it) for it in x] if x is not None else x
+        ),
     )
 
     _data_type = StringField("data_type")

--- a/python/xorbits/_mars/dataframe/core.py
+++ b/python/xorbits/_mars/dataframe/core.py
@@ -962,7 +962,7 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
         return np.asarray(data, dtype=dtype, copy=copy)
 
     def __array__(self, dtype=None, copy=None):
-        return self._to_arr(dtype, copy)
+        return self._to_arr(dtype=dtype, copy=copy)
 
     def _to_mars_tensor(self, dtype=None, order="K", extract_multi_index=False):
         tensor = self.to_tensor(extract_multi_index=extract_multi_index)

--- a/python/xorbits/_mars/dataframe/plotting/tests/test_plot.py
+++ b/python/xorbits/_mars/dataframe/plotting/tests/test_plot.py
@@ -44,7 +44,7 @@ def assert_is_valid_plot_return_object(objs):  # pragma: no cover
     import matplotlib.pyplot as plt
 
     if isinstance(objs, (pd.Series, np.ndarray)):
-        for el in objs.ravel():
+        for el in objs.to_numpy():
             msg = (
                 "one of 'objs' is not a matplotlib Axes instance, "
                 f"type encountered {type(el).__name__}"

--- a/python/xorbits/_mars/dataframe/reduction/core.py
+++ b/python/xorbits/_mars/dataframe/reduction/core.py
@@ -1079,9 +1079,9 @@ class ReductionCompiler:
             if isinstance(t.op, input_op_types):
                 # tileable is an input arg, build a function variable
                 if t.key not in input_key_to_var:  # pragma: no branch
-                    input_key_to_var[t.key] = local_key_to_var[t.key] = (
-                        f"invar{len(input_key_to_var)}"
-                    )
+                    input_key_to_var[t.key] = local_key_to_var[
+                        t.key
+                    ] = f"invar{len(input_key_to_var)}"
             else:
                 keys_to_del = []
                 for inp in t.inputs:

--- a/python/xorbits/_mars/dataframe/reduction/core.py
+++ b/python/xorbits/_mars/dataframe/reduction/core.py
@@ -566,7 +566,7 @@ class DataFrameCumReductionMixin(DataFrameOperandMixin):
             kwargs["skipna"] = op.skipna
         partial = getattr(in_data, getattr(cls, "_func_name"))(**kwargs)
         if op.skipna:
-            partial.fillna(method="ffill", axis=op.axis, inplace=True)
+            partial.ffill(axis=op.axis, inplace=True)
         ctx[op.outputs[0].key] = cls._get_last_slice(op, partial, -1)
 
     @classmethod
@@ -583,7 +583,7 @@ class DataFrameCumReductionMixin(DataFrameOperandMixin):
                 pd.concat(ref_datas, axis=op.axis), getattr(cls, "_func_name")
             )(**kwargs)
             if op.skipna:
-                concat_df.fillna(method="ffill", axis=op.axis, inplace=True)
+                concat_df.ffill(axis=op.axis, inplace=True)
 
             in_data = ctx[op.inputs[0].key]
             concat_df = pd.concat(
@@ -1079,9 +1079,9 @@ class ReductionCompiler:
             if isinstance(t.op, input_op_types):
                 # tileable is an input arg, build a function variable
                 if t.key not in input_key_to_var:  # pragma: no branch
-                    input_key_to_var[t.key] = local_key_to_var[
-                        t.key
-                    ] = f"invar{len(input_key_to_var)}"
+                    input_key_to_var[t.key] = local_key_to_var[t.key] = (
+                        f"invar{len(input_key_to_var)}"
+                    )
             else:
                 keys_to_del = []
                 for inp in t.inputs:

--- a/python/xorbits/_mars/dataframe/statistics/quantile.py
+++ b/python/xorbits/_mars/dataframe/statistics/quantile.py
@@ -106,7 +106,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
             dt = tensor_quantile(
                 tensor_from_series(a[name]),
                 self._q,
-                interpolation=self._interpolation,
+                method=self._interpolation,
                 handle_non_numeric=not self._numeric_only,
             ).dtype
             quantile_dtypes.append(dt)
@@ -152,7 +152,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
             dt = tensor_quantile(
                 empty(a.shape[1], dtype=find_common_type(list(dtypes))),
                 self._q,
-                interpolation=self._interpolation,
+                method=self._interpolation,
                 handle_non_numeric=not self._numeric_only,
             ).dtype
             return self.new_series(
@@ -173,7 +173,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
                     tensor_quantile(
                         tensor_from_series(a[name]),
                         self._q,
-                        interpolation=self._interpolation,
+                        method=self._interpolation,
                         handle_non_numeric=not self._numeric_only,
                     ).dtype
                 )
@@ -222,7 +222,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
         self._dtype = dtype = tensor_quantile(
             a_t,
             self._q,
-            interpolation=self._interpolation,
+            method=self._interpolation,
             handle_non_numeric=not self._numeric_only,
         ).dtype
 
@@ -266,7 +266,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
                     t = tensor_quantile(
                         a,
                         op.q,
-                        interpolation=op.interpolation,
+                        method=op.interpolation,
                         handle_non_numeric=not op.numeric_only,
                     )
                     ts.append(t)
@@ -288,7 +288,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
                     t,
                     op.q,
                     axis=1,
-                    interpolation=op.interpolation,
+                    method=op.interpolation,
                     handle_non_numeric=not op.numeric_only,
                 )
                 r = series_from_tensor(tr, index=op.input.index, name=tr.op.q.item())
@@ -301,7 +301,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
                     t = tensor_quantile(
                         a,
                         op.q,
-                        interpolation=op.interpolation,
+                        method=op.interpolation,
                         handle_non_numeric=not op.numeric_only,
                     )
                     d[name] = t
@@ -315,7 +315,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
                     t,
                     op.q,
                     axis=1,
-                    interpolation=op.interpolation,
+                    method=op.interpolation,
                     handle_non_numeric=not op.numeric_only,
                 )
                 if not op.input.index_value.has_value():
@@ -333,7 +333,7 @@ class DataFrameQuantile(DataFrameOperand, DataFrameOperandMixin):
         t = tensor_quantile(
             a,
             op.q,
-            interpolation=op.interpolation,
+            method=op.interpolation,
             handle_non_numeric=not op.numeric_only,
         )
         if isinstance(op.outputs[0], TENSOR_TYPE):

--- a/python/xorbits/_mars/lib/groupby_wrapper.py
+++ b/python/xorbits/_mars/lib/groupby_wrapper.py
@@ -38,6 +38,7 @@ class GroupByWrapper:
         obj,
         groupby_obj=None,
         keys=None,
+        axis=0,
         level=None,
         exclusions=None,
         selection=None,
@@ -67,6 +68,8 @@ class GroupByWrapper:
 
         self.obj = obj
         self.keys = fill_value(keys, "keys", "_by")
+        # cudf groupby obj has no attribute ``axis``, same as below
+        self.axis = fill_value(axis, "axis")
         self.level = fill_value(level, "level", "_level")
         self.exclusions = fill_value(exclusions, "exclusions")
         self.selection = selection
@@ -79,6 +82,7 @@ class GroupByWrapper:
         if groupby_obj is None:
             groupby_kw = dict(
                 keys=keys,
+                axis=axis,
                 level=level,
                 exclusions=exclusions,
                 as_index=as_index,
@@ -107,6 +111,7 @@ class GroupByWrapper:
         return GroupByWrapper(
             self.obj,
             keys=self.keys,
+            axis=self.axis,
             level=self.level,
             exclusions=self.exclusions,
             selection=item,
@@ -197,6 +202,7 @@ class GroupByWrapper:
         return (
             obj,
             keys,
+            self.axis,
             self.level,
             self.exclusions,
             self.selection,
@@ -213,6 +219,7 @@ class GroupByWrapper:
         (
             obj,
             keys,
+            axis,
             level,
             exclusions,
             selection,
@@ -230,6 +237,7 @@ class GroupByWrapper:
         return cls(
             obj,
             keys=keys,
+            axis=axis,
             level=level,
             exclusions=exclusions,
             selection=selection,
@@ -245,6 +253,7 @@ class GroupByWrapper:
 def wrapped_groupby(
     obj,
     by=None,
+    axis=0,
     level=None,
     as_index=True,
     sort=True,
@@ -254,6 +263,7 @@ def wrapped_groupby(
 ):
     groupby_kw = dict(
         by=by,
+        axis=axis,
         level=level,
         as_index=as_index,
         sort=sort,

--- a/python/xorbits/_mars/lib/groupby_wrapper.py
+++ b/python/xorbits/_mars/lib/groupby_wrapper.py
@@ -39,7 +39,6 @@ class GroupByWrapper:
         groupby_obj=None,
         keys=None,
         level=None,
-        grouper=None,
         exclusions=None,
         selection=None,
         as_index=True,
@@ -81,7 +80,6 @@ class GroupByWrapper:
             groupby_kw = dict(
                 keys=keys,
                 level=level,
-                grouper=grouper,
                 exclusions=exclusions,
                 as_index=as_index,
                 group_keys=group_keys,
@@ -110,7 +108,6 @@ class GroupByWrapper:
             self.obj,
             keys=self.keys,
             level=self.level,
-            grouper=self.groupby_obj.grouper,
             exclusions=self.exclusions,
             selection=item,
             as_index=self.as_index,

--- a/python/xorbits/_mars/lib/groupby_wrapper.py
+++ b/python/xorbits/_mars/lib/groupby_wrapper.py
@@ -38,7 +38,6 @@ class GroupByWrapper:
         obj,
         groupby_obj=None,
         keys=None,
-        axis=0,
         level=None,
         grouper=None,
         exclusions=None,
@@ -69,8 +68,6 @@ class GroupByWrapper:
 
         self.obj = obj
         self.keys = fill_value(keys, "keys", "_by")
-        # cudf groupby obj has no attribute ``axis``, same as below
-        self.axis = fill_value(axis, "axis")
         self.level = fill_value(level, "level", "_level")
         self.exclusions = fill_value(exclusions, "exclusions")
         self.selection = selection
@@ -83,7 +80,6 @@ class GroupByWrapper:
         if groupby_obj is None:
             groupby_kw = dict(
                 keys=keys,
-                axis=axis,
                 level=level,
                 grouper=grouper,
                 exclusions=exclusions,
@@ -113,7 +109,6 @@ class GroupByWrapper:
         return GroupByWrapper(
             self.obj,
             keys=self.keys,
-            axis=self.axis,
             level=self.level,
             grouper=self.groupby_obj.grouper,
             exclusions=self.exclusions,
@@ -205,7 +200,6 @@ class GroupByWrapper:
         return (
             obj,
             keys,
-            self.axis,
             self.level,
             self.exclusions,
             self.selection,
@@ -222,7 +216,6 @@ class GroupByWrapper:
         (
             obj,
             keys,
-            axis,
             level,
             exclusions,
             selection,
@@ -240,7 +233,6 @@ class GroupByWrapper:
         return cls(
             obj,
             keys=keys,
-            axis=axis,
             level=level,
             exclusions=exclusions,
             selection=selection,
@@ -256,7 +248,6 @@ class GroupByWrapper:
 def wrapped_groupby(
     obj,
     by=None,
-    axis=0,
     level=None,
     as_index=True,
     sort=True,
@@ -266,7 +257,6 @@ def wrapped_groupby(
 ):
     groupby_kw = dict(
         by=by,
-        axis=axis,
         level=level,
         as_index=as_index,
         sort=sort,

--- a/python/xorbits/_mars/tensor/statistics/percentile.py
+++ b/python/xorbits/_mars/tensor/statistics/percentile.py
@@ -28,7 +28,7 @@ def percentile(
     axis=None,
     out=None,
     overwrite_input=False,
-    method="linear",
+    interpolation="linear",
     keepdims=False,
 ):
     """
@@ -53,8 +53,8 @@ def percentile(
         but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
         Just for compatibility with Numpy, would not take effect.
-    method : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the method method to
+    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the interpolation method to
         use when the desired percentile lies between two data points
         ``i < j``:
 
@@ -94,7 +94,7 @@ def percentile(
     Given a vector ``V`` of length ``N``, the q-th percentile of
     ``V`` is the value ``q/100`` of the way from the minimum to the
     maximum in a sorted copy of ``V``. The values and distances of
-    the two nearest neighbors as well as the `method` parameter
+    the two nearest neighbors as well as the `interpolation` parameter
     will determine the percentile if the normalized ranking does not
     match the location of ``q`` exactly. This function is the same as
     the median if ``q=50``, the same as the minimum if ``q=0`` and the
@@ -124,7 +124,7 @@ def percentile(
     >>> m.execute()
     array([6.5, 4.5, 2.5])
 
-    The different types of method can be visualized graphically:
+    The different types of interpolation can be visualized graphically:
 
     .. plot::
 
@@ -142,12 +142,12 @@ def percentile(
             ('nearest', '-.'),
             ('midpoint', '-.'),
         ]
-        for method, style in lines:
+        for interpolation, style in lines:
             ax.plot(
-                np.asarray(p), np.asarray(mt.percentile(a, p, method=method)),
-                label=method, linestyle=style)
+                np.asarray(p), np.asarray(mt.percentile(a, p, interpolation=interpolation)),
+                label=interpolation, linestyle=style)
         ax.set(
-            title='method methods for list: ' + str(a),
+            title='Interpolation methods for list: ' + str(a),
             xlabel='Percentile',
             ylabel='List item returned',
             yticks=np.asarray(a))
@@ -170,7 +170,7 @@ def percentile(
         axis=axis,
         out=out,
         overwrite_input=overwrite_input,
-        method=method,
+        interpolation=interpolation,
         keepdims=keepdims,
         q_error_msg=q_error_msg,
     )

--- a/python/xorbits/_mars/tensor/statistics/percentile.py
+++ b/python/xorbits/_mars/tensor/statistics/percentile.py
@@ -28,7 +28,7 @@ def percentile(
     axis=None,
     out=None,
     overwrite_input=False,
-    interpolation="linear",
+    method="linear",
     keepdims=False,
 ):
     """
@@ -53,8 +53,8 @@ def percentile(
         but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
         Just for compatibility with Numpy, would not take effect.
-    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the interpolation method to
+    method : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the method method to
         use when the desired percentile lies between two data points
         ``i < j``:
 
@@ -94,7 +94,7 @@ def percentile(
     Given a vector ``V`` of length ``N``, the q-th percentile of
     ``V`` is the value ``q/100`` of the way from the minimum to the
     maximum in a sorted copy of ``V``. The values and distances of
-    the two nearest neighbors as well as the `interpolation` parameter
+    the two nearest neighbors as well as the `method` parameter
     will determine the percentile if the normalized ranking does not
     match the location of ``q`` exactly. This function is the same as
     the median if ``q=50``, the same as the minimum if ``q=0`` and the
@@ -124,7 +124,7 @@ def percentile(
     >>> m.execute()
     array([6.5, 4.5, 2.5])
 
-    The different types of interpolation can be visualized graphically:
+    The different types of method can be visualized graphically:
 
     .. plot::
 
@@ -142,10 +142,10 @@ def percentile(
             ('nearest', '-.'),
             ('midpoint', '-.'),
         ]
-        for interpolation, style in lines:
+        for method, style in lines:
             ax.plot(
-                np.asarray(p), np.asarray(mt.percentile(a, p, interpolation=interpolation)),
-                label=interpolation, linestyle=style)
+                np.asarray(p), np.asarray(mt.percentile(a, p, method=method)),
+                label=method, linestyle=style)
         ax.set(
             title='Interpolation methods for list: ' + str(a),
             xlabel='Percentile',
@@ -170,7 +170,7 @@ def percentile(
         axis=axis,
         out=out,
         overwrite_input=overwrite_input,
-        interpolation=interpolation,
+        method=method,
         keepdims=keepdims,
         q_error_msg=q_error_msg,
     )

--- a/python/xorbits/_mars/tensor/statistics/percentile.py
+++ b/python/xorbits/_mars/tensor/statistics/percentile.py
@@ -28,7 +28,7 @@ def percentile(
     axis=None,
     out=None,
     overwrite_input=False,
-    interpolation="linear",
+    method="linear",
     keepdims=False,
 ):
     """
@@ -53,8 +53,8 @@ def percentile(
         but the type (of the output) will be cast if necessary.
     overwrite_input : bool, optional
         Just for compatibility with Numpy, would not take effect.
-    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
-        This optional parameter specifies the interpolation method to
+    method : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the method method to
         use when the desired percentile lies between two data points
         ``i < j``:
 
@@ -94,7 +94,7 @@ def percentile(
     Given a vector ``V`` of length ``N``, the q-th percentile of
     ``V`` is the value ``q/100`` of the way from the minimum to the
     maximum in a sorted copy of ``V``. The values and distances of
-    the two nearest neighbors as well as the `interpolation` parameter
+    the two nearest neighbors as well as the `method` parameter
     will determine the percentile if the normalized ranking does not
     match the location of ``q`` exactly. This function is the same as
     the median if ``q=50``, the same as the minimum if ``q=0`` and the
@@ -124,7 +124,7 @@ def percentile(
     >>> m.execute()
     array([6.5, 4.5, 2.5])
 
-    The different types of interpolation can be visualized graphically:
+    The different types of method can be visualized graphically:
 
     .. plot::
 
@@ -142,12 +142,12 @@ def percentile(
             ('nearest', '-.'),
             ('midpoint', '-.'),
         ]
-        for interpolation, style in lines:
+        for method, style in lines:
             ax.plot(
-                np.asarray(p), np.asarray(mt.percentile(a, p, interpolation=interpolation)),
-                label=interpolation, linestyle=style)
+                np.asarray(p), np.asarray(mt.percentile(a, p, method=method)),
+                label=method, linestyle=style)
         ax.set(
-            title='Interpolation methods for list: ' + str(a),
+            title='method methods for list: ' + str(a),
             xlabel='Percentile',
             ylabel='List item returned',
             yticks=np.asarray(a))
@@ -170,7 +170,7 @@ def percentile(
         axis=axis,
         out=out,
         overwrite_input=overwrite_input,
-        interpolation=interpolation,
+        method=method,
         keepdims=keepdims,
         q_error_msg=q_error_msg,
     )

--- a/python/xorbits/_mars/tensor/statistics/quantile.py
+++ b/python/xorbits/_mars/tensor/statistics/quantile.py
@@ -372,16 +372,17 @@ class TensorQuantile(TensorOperand, TensorOperandMixin):
             )
 
 
+# TODO: More methods need be implemented
 METHODS = {
-    "inverted_cdf",
-    "averaged_inverted_cdf",
-    "closest_observation",
-    "interpolated_inverted_cdf",
-    "hazen",
-    "weibull",
+    # "inverted_cdf",
+    # "averaged_inverted_cdf",
+    # "closest_observation",
+    # "interpolated_inverted_cdf",
+    # "hazen",
+    # "weibull",
     "linear",
-    "median_unbiased",
-    "normal_unbiased",
+    # "median_unbiased",
+    # "normal_unbiased",
     "lower",
     "higher",
     "midpoint",

--- a/python/xorbits/_mars/tensor/statistics/quantile.py
+++ b/python/xorbits/_mars/tensor/statistics/quantile.py
@@ -372,7 +372,21 @@ class TensorQuantile(TensorOperand, TensorOperandMixin):
             )
 
 
-INTERPOLATION_TYPES = {"linear", "lower", "higher", "midpoint", "nearest"}
+METHODS = {
+    "inverted_cdf",
+    "averaged_inverted_cdf",
+    "closest_observation",
+    "interpolated_inverted_cdf",
+    "hazen",
+    "weibull",
+    "linear",
+    "median_unbiased",
+    "normal_unbiased",
+    "lower",
+    "higher",
+    "midpoint",
+    "nearest",
+}
 
 
 def _quantile_unchecked(
@@ -410,7 +424,7 @@ def _quantile_unchecked(
     if out is not None and not isinstance(out, TENSOR_TYPE):
         raise TypeError(f"`out` should be a tensor, got {type(out)}")
 
-    if method not in INTERPOLATION_TYPES:
+    if method not in METHODS:
         raise ValueError(
             "method can only be 'linear', 'lower' " "'higher', 'midpoint', or 'nearest'"
         )

--- a/python/xorbits/_mars/tensor/statistics/quantile.py
+++ b/python/xorbits/_mars/tensor/statistics/quantile.py
@@ -372,7 +372,7 @@ class TensorQuantile(TensorOperand, TensorOperandMixin):
             )
 
 
-METHOD_TYPES = {"linear", "lower", "higher", "midpoint", "nearest"}
+INTERPOLATION_TYPES = {"linear", "lower", "higher", "midpoint", "nearest"}
 
 
 def _quantile_unchecked(
@@ -410,7 +410,7 @@ def _quantile_unchecked(
     if out is not None and not isinstance(out, TENSOR_TYPE):
         raise TypeError(f"`out` should be a tensor, got {type(out)}")
 
-    if method not in METHOD_TYPES:
+    if method not in INTERPOLATION_TYPES:
         raise ValueError(
             "method can only be 'linear', 'lower' " "'higher', 'midpoint', or 'nearest'"
         )

--- a/python/xorbits/_mars/tensor/statistics/quantile.py
+++ b/python/xorbits/_mars/tensor/statistics/quantile.py
@@ -412,8 +412,7 @@ def _quantile_unchecked(
 
     if method not in METHOD_TYPES:
         raise ValueError(
-            "method can only be 'linear', 'lower' "
-            "'higher', 'midpoint', or 'nearest'"
+            "method can only be 'linear', 'lower' " "'higher', 'midpoint', or 'nearest'"
         )
 
     # infer dtype
@@ -421,9 +420,7 @@ def _quantile_unchecked(
     if handle_non_numeric and not np.issubdtype(a.dtype, np.number):
         dtype = a.dtype
     else:
-        dtype = np.quantile(
-            np.empty(1, dtype=a.dtype), q_tiny, method=method
-        ).dtype
+        dtype = np.quantile(np.empty(1, dtype=a.dtype), q_tiny, method=method).dtype
     op = TensorQuantile(
         q=q,
         axis=axis,

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
@@ -19,7 +19,7 @@ import pytest
 from ....core import tile
 from ...datasource import array, tensor
 from .. import digitize, histogram_bin_edges, percentile, quantile
-from ..quantile import INTERPOLATION_TYPES
+from ..quantile import METHODS
 
 
 def test_digitize():
@@ -87,19 +87,17 @@ def test_quantile():
 
     for dtype in [np.float32, np.int64]:
         for axis in (None, 0, 1, [0, 1]):
-            for interpolation in INTERPOLATION_TYPES:
+            for method in METHODS:
                 for keepdims in [True, False]:
                     raw2 = raw.astype(dtype)
                     a = tensor(raw2, chunk_size=(8, 6))
 
-                    b = quantile(
-                        a, q, axis=axis, method=interpolation, keepdims=keepdims
-                    )
+                    b = quantile(a, q, axis=axis, method=method, keepdims=keepdims)
                     expected = np.quantile(
                         raw2,
                         q,
                         axis=axis,
-                        method=interpolation,
+                        method=method,
                         keepdims=keepdims,
                     )
                     assert b.shape == expected.shape
@@ -143,7 +141,7 @@ def test_quantile():
         q2[0] = 1.1
         quantile(a, q2)
 
-    # wrong interpolation
+    # wrong method
     with pytest.raises(ValueError):
         quantile(a, q, method="unknown")
 

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
@@ -19,7 +19,7 @@ import pytest
 from ....core import tile
 from ...datasource import array, tensor
 from .. import digitize, histogram_bin_edges, percentile, quantile
-from ..quantile import INTERPOLATION_TYPES
+from ..quantile import METHOD_TYPES
 
 
 def test_digitize():
@@ -87,7 +87,7 @@ def test_quantile():
 
     for dtype in [np.float32, np.int64]:
         for axis in (None, 0, 1, [0, 1]):
-            for interpolation in INTERPOLATION_TYPES:
+            for interpolation in METHOD_TYPES:
                 for keepdims in [True, False]:
                     raw2 = raw.astype(dtype)
                     a = tensor(raw2, chunk_size=(8, 6))

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics.py
@@ -19,7 +19,7 @@ import pytest
 from ....core import tile
 from ...datasource import array, tensor
 from .. import digitize, histogram_bin_edges, percentile, quantile
-from ..quantile import METHOD_TYPES
+from ..quantile import INTERPOLATION_TYPES
 
 
 def test_digitize():
@@ -87,19 +87,19 @@ def test_quantile():
 
     for dtype in [np.float32, np.int64]:
         for axis in (None, 0, 1, [0, 1]):
-            for interpolation in METHOD_TYPES:
+            for interpolation in INTERPOLATION_TYPES:
                 for keepdims in [True, False]:
                     raw2 = raw.astype(dtype)
                     a = tensor(raw2, chunk_size=(8, 6))
 
                     b = quantile(
-                        a, q, axis=axis, interpolation=interpolation, keepdims=keepdims
+                        a, q, axis=axis, method=interpolation, keepdims=keepdims
                     )
                     expected = np.quantile(
                         raw2,
                         q,
                         axis=axis,
-                        interpolation=interpolation,
+                        method=interpolation,
                         keepdims=keepdims,
                     )
                     assert b.shape == expected.shape
@@ -145,7 +145,7 @@ def test_quantile():
 
     # wrong interpolation
     with pytest.raises(ValueError):
-        quantile(a, q, interpolation="unknown")
+        quantile(a, q, method="unknown")
 
 
 def test_percentile():

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
@@ -35,7 +35,7 @@ from .. import (
     ptp,
     quantile,
 )
-from ..quantile import METHOD_TYPES
+from ..quantile import INTERPOLATION_TYPES
 
 
 def test_average_execution(setup):
@@ -299,7 +299,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in METHOD_TYPES:
+        for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
                 r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
 
@@ -328,7 +328,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in METHOD_TYPES:
+        for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(
@@ -370,7 +370,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in METHOD_TYPES:
+        for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
                 r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
 
@@ -399,7 +399,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=(12, 6))
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in METHOD_TYPES:
+        for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
@@ -301,20 +301,20 @@ def test_quantile_execution(setup):
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
         for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
-                r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
+                r = quantile(a, q, method=interpolation, keepdims=keepdims)
 
                 result = r.execute().fetch()
                 expected = np.quantile(
-                    raw, q, interpolation=interpolation, keepdims=keepdims
+                    raw, q, method=interpolation, keepdims=keepdims
                 )
 
                 np.testing.assert_array_equal(result, expected)
 
-                r2 = quantile(a2, q, interpolation=interpolation, keepdims=keepdims)
+                r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
 
                 result = r2.execute().fetch()
                 expected = np.quantile(
-                    raw2, q, interpolation=interpolation, keepdims=keepdims
+                    raw2, q, method=interpolation, keepdims=keepdims
                 )
 
                 np.testing.assert_array_equal(result, expected)
@@ -332,7 +332,7 @@ def test_quantile_execution(setup):
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(
-                        a, q, axis=axis, interpolation=interpolation, keepdims=keepdims
+                        a, q, axis=axis, method=interpolation, keepdims=keepdims
                     )
 
                     result = r.execute().fetch()
@@ -340,14 +340,14 @@ def test_quantile_execution(setup):
                         raw,
                         q,
                         axis=axis,
-                        interpolation=interpolation,
+                        method=interpolation,
                         keepdims=keepdims,
                     )
 
                     np.testing.assert_array_equal(result, expected)
 
                     r2 = quantile(
-                        a2, q, axis=axis, interpolation=interpolation, keepdims=keepdims
+                        a2, q, axis=axis, method=interpolation, keepdims=keepdims
                     )
 
                     result = r2.execute().fetch()
@@ -355,7 +355,7 @@ def test_quantile_execution(setup):
                         raw2,
                         q,
                         axis=axis,
-                        interpolation=interpolation,
+                        method=interpolation,
                         keepdims=keepdims,
                     )
 
@@ -372,20 +372,20 @@ def test_quantile_execution(setup):
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
         for interpolation in INTERPOLATION_TYPES:
             for keepdims in [True, False]:
-                r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
+                r = quantile(a, q, method=interpolation, keepdims=keepdims)
 
                 result = r.execute().fetch()
                 expected = np.quantile(
-                    raw, q, interpolation=interpolation, keepdims=keepdims
+                    raw, q, method=interpolation, keepdims=keepdims
                 )
 
                 np.testing.assert_almost_equal(result, expected)
 
-                r2 = quantile(a2, q, interpolation=interpolation, keepdims=keepdims)
+                r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
 
                 result = r2.execute().fetch()
                 expected = np.quantile(
-                    raw2, q, interpolation=interpolation, keepdims=keepdims
+                    raw2, q, method=interpolation, keepdims=keepdims
                 )
 
                 np.testing.assert_almost_equal(result, expected)
@@ -403,7 +403,7 @@ def test_quantile_execution(setup):
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(
-                        a, q, axis=axis, interpolation=interpolation, keepdims=keepdims
+                        a, q, axis=axis, method=interpolation, keepdims=keepdims
                     )
 
                     result = r.execute().fetch()
@@ -411,14 +411,14 @@ def test_quantile_execution(setup):
                         raw,
                         q,
                         axis=axis,
-                        interpolation=interpolation,
+                        method=interpolation,
                         keepdims=keepdims,
                     )
 
                     np.testing.assert_almost_equal(result, expected)
 
                     r2 = quantile(
-                        a2, q, axis=axis, interpolation=interpolation, keepdims=keepdims
+                        a2, q, axis=axis, method=interpolation, keepdims=keepdims
                     )
 
                     result = r2.execute().fetch()
@@ -426,7 +426,7 @@ def test_quantile_execution(setup):
                         raw2,
                         q,
                         axis=axis,
-                        interpolation=interpolation,
+                        method=interpolation,
                         keepdims=keepdims,
                     )
 

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
@@ -35,7 +35,7 @@ from .. import (
     ptp,
     quantile,
 )
-from ..quantile import INTERPOLATION_TYPES
+from ..quantile import METHODS
 
 
 def test_average_execution(setup):
@@ -299,19 +299,19 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for method in METHODS:
             for keepdims in [True, False]:
-                r = quantile(a, q, method=interpolation, keepdims=keepdims)
+                r = quantile(a, q, method=method, keepdims=keepdims)
 
                 result = r.execute().fetch()
-                expected = np.quantile(raw, q, method=interpolation, keepdims=keepdims)
+                expected = np.quantile(raw, q, method=method, keepdims=keepdims)
 
                 np.testing.assert_array_equal(result, expected)
 
-                r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
+                r2 = quantile(a2, q, method=method, keepdims=keepdims)
 
                 result = r2.execute().fetch()
-                expected = np.quantile(raw2, q, method=interpolation, keepdims=keepdims)
+                expected = np.quantile(raw2, q, method=method, keepdims=keepdims)
 
                 np.testing.assert_array_equal(result, expected)
 
@@ -324,34 +324,30 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for method in METHODS:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
-                    r = quantile(
-                        a, q, axis=axis, method=interpolation, keepdims=keepdims
-                    )
+                    r = quantile(a, q, axis=axis, method=method, keepdims=keepdims)
 
                     result = r.execute().fetch()
                     expected = np.quantile(
                         raw,
                         q,
                         axis=axis,
-                        method=interpolation,
+                        method=method,
                         keepdims=keepdims,
                     )
 
                     np.testing.assert_array_equal(result, expected)
 
-                    r2 = quantile(
-                        a2, q, axis=axis, method=interpolation, keepdims=keepdims
-                    )
+                    r2 = quantile(a2, q, axis=axis, method=method, keepdims=keepdims)
 
                     result = r2.execute().fetch()
                     expected = np.quantile(
                         raw2,
                         q,
                         axis=axis,
-                        method=interpolation,
+                        method=method,
                         keepdims=keepdims,
                     )
 
@@ -366,19 +362,19 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for method in METHODS:
             for keepdims in [True, False]:
-                r = quantile(a, q, method=interpolation, keepdims=keepdims)
+                r = quantile(a, q, method=method, keepdims=keepdims)
 
                 result = r.execute().fetch()
-                expected = np.quantile(raw, q, method=interpolation, keepdims=keepdims)
+                expected = np.quantile(raw, q, method=method, keepdims=keepdims)
 
                 np.testing.assert_almost_equal(result, expected)
 
-                r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
+                r2 = quantile(a2, q, method=method, keepdims=keepdims)
 
                 result = r2.execute().fetch()
-                expected = np.quantile(raw2, q, method=interpolation, keepdims=keepdims)
+                expected = np.quantile(raw2, q, method=method, keepdims=keepdims)
 
                 np.testing.assert_almost_equal(result, expected)
 
@@ -391,34 +387,30 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=(12, 6))
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for method in METHODS:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
-                    r = quantile(
-                        a, q, axis=axis, method=interpolation, keepdims=keepdims
-                    )
+                    r = quantile(a, q, axis=axis, method=method, keepdims=keepdims)
 
                     result = r.execute().fetch()
                     expected = np.quantile(
                         raw,
                         q,
                         axis=axis,
-                        method=interpolation,
+                        method=method,
                         keepdims=keepdims,
                     )
 
                     np.testing.assert_almost_equal(result, expected)
 
-                    r2 = quantile(
-                        a2, q, axis=axis, method=interpolation, keepdims=keepdims
-                    )
+                    r2 = quantile(a2, q, axis=axis, method=method, keepdims=keepdims)
 
                     result = r2.execute().fetch()
                     expected = np.quantile(
                         raw2,
                         q,
                         axis=axis,
-                        method=interpolation,
+                        method=method,
                         keepdims=keepdims,
                     )
 

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
@@ -35,7 +35,7 @@ from .. import (
     ptp,
     quantile,
 )
-from ..quantile import INTERPOLATION_TYPES
+from ..quantile import METHOD_TYPES
 
 
 def test_average_execution(setup):
@@ -299,7 +299,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for interpolation in METHOD_TYPES:
             for keepdims in [True, False]:
                 r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
 
@@ -328,7 +328,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for interpolation in METHOD_TYPES:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(
@@ -370,7 +370,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=20)
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for interpolation in METHOD_TYPES:
             for keepdims in [True, False]:
                 r = quantile(a, q, interpolation=interpolation, keepdims=keepdims)
 
@@ -399,7 +399,7 @@ def test_quantile_execution(setup):
     a2 = tensor(raw2, chunk_size=(12, 6))
 
     for q in [np.random.RandomState(0).rand(), np.random.RandomState(0).rand(5)]:
-        for interpolation in INTERPOLATION_TYPES:
+        for interpolation in METHOD_TYPES:
             for keepdims in [True, False]:
                 for axis in [None, 0, 1]:
                     r = quantile(

--- a/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
+++ b/python/xorbits/_mars/tensor/statistics/tests/test_statistics_execution.py
@@ -304,18 +304,14 @@ def test_quantile_execution(setup):
                 r = quantile(a, q, method=interpolation, keepdims=keepdims)
 
                 result = r.execute().fetch()
-                expected = np.quantile(
-                    raw, q, method=interpolation, keepdims=keepdims
-                )
+                expected = np.quantile(raw, q, method=interpolation, keepdims=keepdims)
 
                 np.testing.assert_array_equal(result, expected)
 
                 r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
 
                 result = r2.execute().fetch()
-                expected = np.quantile(
-                    raw2, q, method=interpolation, keepdims=keepdims
-                )
+                expected = np.quantile(raw2, q, method=interpolation, keepdims=keepdims)
 
                 np.testing.assert_array_equal(result, expected)
 
@@ -375,18 +371,14 @@ def test_quantile_execution(setup):
                 r = quantile(a, q, method=interpolation, keepdims=keepdims)
 
                 result = r.execute().fetch()
-                expected = np.quantile(
-                    raw, q, method=interpolation, keepdims=keepdims
-                )
+                expected = np.quantile(raw, q, method=interpolation, keepdims=keepdims)
 
                 np.testing.assert_almost_equal(result, expected)
 
                 r2 = quantile(a2, q, method=interpolation, keepdims=keepdims)
 
                 result = r2.execute().fetch()
-                expected = np.quantile(
-                    raw2, q, method=interpolation, keepdims=keepdims
-                )
+                expected = np.quantile(raw2, q, method=interpolation, keepdims=keepdims)
 
                 np.testing.assert_almost_equal(result, expected)
 

--- a/python/xorbits/_mars/utils.py
+++ b/python/xorbits/_mars/utils.py
@@ -755,7 +755,6 @@ def merge_chunks(chunk_results: List[Tuple[Tuple[int], Any]]) -> Any:
             df,
             None,
             keys=keys,
-            axis=v.axis,
             level=v.level,
             exclusions=v.exclusions,
             selection=v.selection,

--- a/python/xorbits/_mars/utils.py
+++ b/python/xorbits/_mars/utils.py
@@ -755,6 +755,7 @@ def merge_chunks(chunk_results: List[Tuple[Tuple[int], Any]]) -> Any:
             df,
             None,
             keys=keys,
+            axis=v.axis,
             level=v.level,
             exclusions=v.exclusions,
             selection=v.selection,

--- a/python/xorbits/core/data.py
+++ b/python/xorbits/core/data.py
@@ -133,9 +133,9 @@ class Data:
         else:  # pragma: no cover
             return super().__repr__()
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         if self._mars_entity is not None:
-            return self._mars_entity.__array__()
+            return self._mars_entity.__array__(dtype=dtype, copy=copy)
         else:  # pragma: no cover
             raise AttributeError("__array__")
 
@@ -310,14 +310,14 @@ class DataRef(metaclass=DataRefMeta):
             run(self)
             return self.data.__repr__()
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         from .execution import run
 
         if self._own_data():
-            return self.data._mars_entity.op.data.__array__()
+            return self.data._mars_entity.op.data.__array__(dtype=dtype, copy=copy)
         else:
             run(self)
-            return self.data.__array__()
+            return self.data.__array__(dtype=dtype, copy=copy)
 
     def _to_int_or_float(self, conversion: AutoConversionType, cast: bool = False):
         from .execution import run


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

- Numpy 2.x needs `__array__` must implement 'dtype' and 'copy' keyword arguments. Reference https://numpy.org/doc/stable/user/basics.interoperability.html#dunder-array-interface
- Parameter `interpolation` has been renamed to `method` in `percentile` and `quantile` above Numpy version 1.22.x
- Parameter `grouper` in `group_by` has been removed because it is deprecated and has been removed in latest version of pandas.
<!-- Please give a short brief about these changes. -->


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
